### PR TITLE
Fix #76: Profile crash for some users

### DIFF
--- a/src/post/PostCard/PostCardBody/index.js
+++ b/src/post/PostCard/PostCardBody/index.js
@@ -22,7 +22,9 @@ const PostCardBody = ({ post }) => {
 
   let image = _.get(jsonMetadata, 'image[0]', '');
 
-  if (!image.length) {
+  if ( // Image is null for some rare cases - prevent crash
+    !image || !image.length
+  ) {
     image = _.get(getImagesFromBody(post.body), '[0]', '');
   }
 


### PR DESCRIPTION
`json_metadata.image` array is `[null, ]` for some posts (e.g. https://steemit.com/hapramp/@tobias-g/test-20180813081339.json) and the app crashed while trying to evaluate `.length` of it.

The fix includes checking that image is not `null` in the first case.

Fixes #76.