### PR TITLE
Fix parent author/permlink issue for root replies

### DIFF
--- a/src/post/PostSingle/index.js
+++ b/src/post/PostSingle/index.js
@@ -47,6 +47,7 @@ class PostSingle extends React.Component {
           <div>
             <Replies
               permlinks={this.props.post.replies}
+              rootPost={this.props.post}
             />
           </div>
         </div>


### PR DESCRIPTION
The component `<RootReplies />` was missing the `rootPost` prop from the parent.

Fix #79.