### PR TITLE
Fix posts with same title

### DIFF
--- a/src/utils/steem.js
+++ b/src/utils/steem.js
@@ -163,7 +163,11 @@ class SteemAPI {
 
   static createPermlink(title, author, parentAuthor, parentPermlink) {
     let permlink;
-    const timeStr = new Date().toISOString().replace(/[^a-zA-Z0-9]+/g, '');
+
+    const timeStr = new Date().toISOString()
+      .replace(/[^a-zA-Z0-9]+/g, '')
+      .toLowerCase(); // permlink can't have capital case characters
+
     if (title && title.trim() !== '') {
       let s = slug(title);
       if (s === '') {
@@ -172,7 +176,6 @@ class SteemAPI {
 
       return this.loadPost(author, s)
         .then((content) => {
-          console.log(content);
           let prefix;
           if (content.posts[0].body !== '') {
             // make sure slug is unique


### PR DESCRIPTION
When there was a post with a duplicate title, a date based string was appended to the beginning of the permlink which also had some capital letters in it. This caused the post create method to fail.

Fix #81.