### PR TITLE
Fix no replies

### DIFF
--- a/src/lib/sanitizeConfig.js
+++ b/src/lib/sanitizeConfig.js
@@ -103,7 +103,7 @@ export default ({ large = true, noImage = false, sanitizeErrors = [], secureLink
               webkitallowfullscreen: 'webkitallowfullscreen', // deprecated but required for vimeo : https://vimeo.com/forums/help/topic:278181
               mozallowfullscreen: 'mozallowfullscreen', // deprecated but required for vimeo
               src,
-              width: large ? '640' : '480',
+              width: '100%',
               height: large ? '360' : '270',
             },
           };

--- a/src/post/reducer.js
+++ b/src/post/reducer.js
@@ -22,7 +22,7 @@ export default (state = initialState, action) => {
          *  if winners are fetched before post, the prize related keys
          *  will be overwritten when updating the post here.
          */
-        const post = { ...newPost, ...oldPost };
+        const post = { ...oldPost, ...newPost };
 
         if (typeof (post.json_metadata) === 'string') {
           try {


### PR DESCRIPTION
The new post keys were being overwritten by older one after fetching replies. Due to this, the `replies` array always remained empty.