### PR TITLE
Hotfix: Fix profile not loading for usernames containing .

### DIFF
--- a/src/profile/reducer.js
+++ b/src/profile/reducer.js
@@ -115,7 +115,7 @@ export const getFollowingCount = (state, username) => _.get(
 
 export const getUserProfile = (state, username) => _.get(
   state.userProfile,
-  `[${username}]`,
+  `['${username}']`,
   getEmptyProfileData(),
 );
 


### PR DESCRIPTION
While fetching user profile, the component was trying to get the data from `aaa: { bbb: { ... {...} } }` instead of `aaa.bbb: { ... {...} } `.

Fixed by referencing with `x['aaa.bbb']` instead of `x[aaa.bbb]`.