### PR TITLE
Add feature to create competition and declare winners

### DIFF
--- a/src/competitions/CompetitionListing/index.js
+++ b/src/competitions/CompetitionListing/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
@@ -17,38 +17,47 @@ import PostLoading from '../../post/PostLoading';
 
 const CompetitionListing = ({
   isFetching, competitions, getAllCompetitions, hasMore,
-}) => (
-  <div className={`${styles.container}`}>
-    <Helmet>
-      <title>Competitions | 1Ramp</title>
-      <meta name="title" content="Competitions | 1Ramp" />
-      <meta name="twitter:title" content="Competitions | 1Ramp" />
-      <meta name="og:title" content="Competitions | 1Ramp" />
-      <meta name="description" content="Participate in contests and win exciting prizes" />
-      <meta name="twitter:description" content="Participate in contests and win exciting prizes" />
-      <meta name="og:description" content="Participate in contests and win exciting prizes" />
-      <meta name="og:url" content="https://alpha.1ramp.io/competitions" />
-    </Helmet>
-    <div>
-      <Leaderboard />
+}) => {
+  const [hasFetchedOnce, setFetchedOnce] = useState(false);
+  return (
+    <div className={`${styles.container}`}>
+      <Helmet>
+        <title>Competitions | 1Ramp</title>
+        <meta name="title" content="Competitions | 1Ramp" />
+        <meta name="twitter:title" content="Competitions | 1Ramp" />
+        <meta name="og:title" content="Competitions | 1Ramp" />
+        <meta name="description" content="Participate in contests and win exciting prizes" />
+        <meta name="twitter:description" content="Participate in contests and win exciting prizes" />
+        <meta name="og:description" content="Participate in contests and win exciting prizes" />
+        <meta name="og:url" content="https://alpha.1ramp.io/competitions" />
+      </Helmet>
+      <div>
+        <Leaderboard />
+      </div>
+      <InfiniteScroller
+        pageStart={0}
+        loadMore={() => {
+          if (!isFetching) {
+            // Reload if fetching for the first time
+            getAllCompetitions(!hasFetchedOnce);
+            setFetchedOnce(true);
+          }
+        }}
+        hasMore={hasMore}
+        className="uk-grid"
+        loader={<div className="uk-width-1-2@m"><PostLoading /></div>}
+      >
+        {
+          competitions.map(competition => (
+            <div key={competition.id} className={`uk-width-1-2@m ${styles.competitionCardContainer}`}>
+              <CompetitionCard competition={competition} />
+            </div>
+          ))
+        }
+      </InfiniteScroller>
     </div>
-    <InfiniteScroller
-      pageStart={0}
-      loadMore={() => (!isFetching) && getAllCompetitions(false)}
-      hasMore={hasMore}
-      className="uk-grid"
-      loader={<div className="uk-width-1-2@m"><PostLoading /></div>}
-    >
-      {
-        competitions.map(competition => (
-          <div key={competition.id} className={`uk-width-1-2@m ${styles.competitionCardContainer}`}>
-            <CompetitionCard competition={competition} />
-          </div>
-        ))
-      }
-    </InfiniteScroller>
-  </div>
-);
+  );
+};
 
 CompetitionListing.propTypes = {
   isFetching: PropTypes.bool.isRequired,

--- a/src/competitions/CompetitionListing/index.js
+++ b/src/competitions/CompetitionListing/index.js
@@ -1,62 +1,66 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet-async';
+import InfiniteScroller from 'react-infinite-scroller';
 
 import {
   getAllCompetitions as getAllCompetitionsSelector,
-  isCompetitionsFetching,
+  isCompetitionsFetching, hasMore as hasMoreCompetitions,
 } from '../reducer';
 import { getAllCompetitions as getAllCompetitionsAction } from '../actions';
 import styles from './styles.scss';
 import CompetitionCard from '../CompetitionCard';
 import Leaderboard from '../Leaderboard';
+import PostLoading from '../../post/PostLoading';
 
-const CompetitionListing = ({ isFetching, competitions, getAllCompetitions }) => {
-  useEffect(() => {
-    if (!isFetching) {
-      getAllCompetitions();
-    }
-  }, true);
-
-  return (
-    <div className={`${styles.container}`}>
-      <Helmet>
-        <title>Competitions | 1Ramp</title>
-        <meta name="title" content="Competitions | 1Ramp" />
-        <meta name="twitter:title" content="Competitions | 1Ramp" />
-        <meta name="og:title" content="Competitions | 1Ramp" />
-        <meta name="description" content="Participate in contests and win exciting prizes" />
-        <meta name="twitter:description" content="Participate in contests and win exciting prizes" />
-        <meta name="og:description" content="Participate in contests and win exciting prizes" />
-        <meta name="og:url" content="https://alpha.1ramp.io/competitions" />
-      </Helmet>
-      <div>
-        <Leaderboard />
-      </div>
-      <div className="uk-grid">
-        {
-          competitions.map(competition => (
-            <div key={competition.id} className={`uk-width-1-2@m ${styles.competitionCardContainer}`}>
-              <CompetitionCard competition={competition} />
-            </div>
-          ))
-        }
-      </div>
+const CompetitionListing = ({
+  isFetching, competitions, getAllCompetitions, hasMore,
+}) => (
+  <div className={`${styles.container}`}>
+    <Helmet>
+      <title>Competitions | 1Ramp</title>
+      <meta name="title" content="Competitions | 1Ramp" />
+      <meta name="twitter:title" content="Competitions | 1Ramp" />
+      <meta name="og:title" content="Competitions | 1Ramp" />
+      <meta name="description" content="Participate in contests and win exciting prizes" />
+      <meta name="twitter:description" content="Participate in contests and win exciting prizes" />
+      <meta name="og:description" content="Participate in contests and win exciting prizes" />
+      <meta name="og:url" content="https://alpha.1ramp.io/competitions" />
+    </Helmet>
+    <div>
+      <Leaderboard />
     </div>
-  );
-};
+    <InfiniteScroller
+      pageStart={0}
+      loadMore={() => (!isFetching) && getAllCompetitions(false)}
+      hasMore={hasMore}
+      className="uk-grid"
+      loader={<div className="uk-width-1-2@m"><PostLoading /></div>}
+    >
+      {
+        competitions.map(competition => (
+          <div key={competition.id} className={`uk-width-1-2@m ${styles.competitionCardContainer}`}>
+            <CompetitionCard competition={competition} />
+          </div>
+        ))
+      }
+    </InfiniteScroller>
+  </div>
+);
 
 CompetitionListing.propTypes = {
   isFetching: PropTypes.bool.isRequired,
   competitions: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   getAllCompetitions: PropTypes.func.isRequired,
+  hasMore: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
   competitions: getAllCompetitionsSelector(state),
   isFetching: isCompetitionsFetching(state),
+  hasMore: hasMoreCompetitions(state),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(

--- a/src/competitions/CompetitionSingle/index.js
+++ b/src/competitions/CompetitionSingle/index.js
@@ -19,7 +19,7 @@ import styles from './styles.scss';
 
 import { getSumPrize, getFormattedDate, isParticipatePossible } from '../utils';
 import {
-  getPostsForCompetition, getAllCompetitions, getCompetitionWinners,
+  getPostsForCompetition, getCompetitionById as fetchCompetitionById, getCompetitionWinners,
   participateInCompetition,
 } from '../actions';
 import { getCompetitionPostPermlinks, getCompetitionById, isPostsLoading } from '../reducer';
@@ -27,14 +27,14 @@ import { getAuthUsername } from '../../reducers/authUserReducer';
 import { getCompleteHTML } from '../../post/utils';
 
 const CompetitionSingle = ({
-  match, postPermlinks, fetchPosts, fetchCompetitions,
+  match, postPermlinks, fetchPosts, fetchCompetition,
   competition, fetchWinners, participate, authUsername,
   ...props
 }) => {
   const { competitionId } = match.params;
   useEffect(
     () => {
-      fetchCompetitions();
+      fetchCompetition(competitionId);
       fetchPosts(competitionId);
     },
     [competitionId],
@@ -200,7 +200,7 @@ CompetitionSingle.propTypes = {
   match: PropTypes.shape().isRequired,
   postPermlinks: PropTypes.arrayOf(PropTypes.string).isRequired,
   fetchPosts: PropTypes.func.isRequired,
-  fetchCompetitions: PropTypes.func.isRequired,
+  fetchCompetition: PropTypes.func.isRequired,
   competition: PropTypes.shape(),
   fetchWinners: PropTypes.func.isRequired,
   participate: PropTypes.func.isRequired,
@@ -223,7 +223,7 @@ const mapStateToProps = (state, ownProps) => ({
 const mapDispatchToProps = dispatch => bindActionCreators(
   {
     fetchPosts: getPostsForCompetition,
-    fetchCompetitions: getAllCompetitions,
+    fetchCompetition: fetchCompetitionById,
     fetchWinners: getCompetitionWinners,
     participate: participateInCompetition,
   },

--- a/src/competitions/CompetitionSingle/index.js
+++ b/src/competitions/CompetitionSingle/index.js
@@ -171,7 +171,7 @@ const CompetitionSingle = ({
           {
             // Render competition winner declation post creation button
             canDeclareWinnersPost && (
-              <Link to={`/competitions/~create/post/${competition.id}/declare_winners`}>
+              <Link to={`/competitions/~create/post/${competition.id}/declare-winners`}>
                 <PrimaryButton style={{ width: 'fit-content', padding: '8px 24px' }}>
                   Post Winner Announcement
                 </PrimaryButton>

--- a/src/competitions/CompetitionSingle/index.js
+++ b/src/competitions/CompetitionSingle/index.js
@@ -25,7 +25,7 @@ import {
 } from '../actions';
 import {
   getCompetitionPostPermlinks, getCompetitionById, isPostsLoading,
-  isWinnerDeclareAllowed,
+  isWinnerDeclareAllowed, isAnnouncePostAllowed, isDeclareWinnerPostAllowed,
 } from '../reducer';
 import { getAuthUsername } from '../../reducers/authUserReducer';
 import { getCompleteHTML } from '../../post/utils';
@@ -34,7 +34,8 @@ import PrimaryButton from '../../components/buttons/PrimaryButton';
 const CompetitionSingle = ({
   match, postPermlinks, fetchPosts, fetchCompetition,
   competition, fetchWinners, participate, authUsername,
-  canDeclareResults, ...props
+  canDeclareResults, canAnnounce, canDeclareWinnersPost,
+  ...props
 }) => {
   const { competitionId } = match.params;
   useEffect(
@@ -144,16 +145,40 @@ const CompetitionSingle = ({
             />
           )
         }
-        {
-          // Render declare winners button if allowed
-          canDeclareResults && (
-            <Link to={`/competitions/~create/declare-winners/${competition.id}`}>
-              <PrimaryButton style={{ width: 'fit-content', padding: '8px 24px' }}>
-                Declare Results
-              </PrimaryButton>
-            </Link>
-          )
-        }
+
+        {/* Buttons that only contest creator can see */}
+        <div className="uk-grid">
+          {
+            // Render declare winners button if allowed
+            canDeclareResults && (
+              <Link to={`/competitions/~create/declare-winners/${competition.id}`} className="uk-margin-small-bottom">
+                <PrimaryButton style={{ width: 'fit-content', padding: '8px 24px' }}>
+                  Declare Results
+                </PrimaryButton>
+              </Link>
+            )
+          }
+          {
+            // Render competition announcement post creation button
+            canAnnounce && (
+              <Link to={`/competitions/~create/post/${competition.id}/announce`} className="uk-margin-small-bottom">
+                <PrimaryButton style={{ width: 'fit-content', padding: '8px 24px' }}>
+                  Post Competition Announcement
+                </PrimaryButton>
+              </Link>
+            )
+          }
+          {
+            // Render competition winner declation post creation button
+            canDeclareWinnersPost && (
+              <Link to={`/competitions/~create/post/${competition.id}/declare_winners`}>
+                <PrimaryButton style={{ width: 'fit-content', padding: '8px 24px' }}>
+                  Post Winner Announcement
+                </PrimaryButton>
+              </Link>
+            )
+          }
+        </div>
 
         {/** Hashtag info */}
         <div className={styles.hashTagText}>
@@ -222,6 +247,8 @@ CompetitionSingle.propTypes = {
   authUsername: PropTypes.string,
   isPostsLoading: PropTypes.bool.isRequired,
   canDeclareResults: PropTypes.bool.isRequired,
+  canAnnounce: PropTypes.bool.isRequired,
+  canDeclareWinnersPost: PropTypes.bool.isRequired,
 };
 
 CompetitionSingle.defaultProps = {
@@ -235,6 +262,8 @@ const mapStateToProps = (state, ownProps) => ({
   authUsername: getAuthUsername(state),
   isPostsLoading: isPostsLoading(state, ownProps.match.params.competitionId),
   canDeclareResults: isWinnerDeclareAllowed(state, ownProps.match.params.competitionId),
+  canAnnounce: isAnnouncePostAllowed(state, ownProps.match.params.competitionId),
+  canDeclareWinnersPost: isDeclareWinnerPostAllowed(state, ownProps.match.params.competitionId),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(

--- a/src/competitions/CompetitionSingle/index.js
+++ b/src/competitions/CompetitionSingle/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import ordinal from 'ordinal-js';
@@ -22,14 +23,18 @@ import {
   getPostsForCompetition, getCompetitionById as fetchCompetitionById, getCompetitionWinners,
   participateInCompetition,
 } from '../actions';
-import { getCompetitionPostPermlinks, getCompetitionById, isPostsLoading } from '../reducer';
+import {
+  getCompetitionPostPermlinks, getCompetitionById, isPostsLoading,
+  isWinnerDeclareAllowed,
+} from '../reducer';
 import { getAuthUsername } from '../../reducers/authUserReducer';
 import { getCompleteHTML } from '../../post/utils';
+import PrimaryButton from '../../components/buttons/PrimaryButton';
 
 const CompetitionSingle = ({
   match, postPermlinks, fetchPosts, fetchCompetition,
   competition, fetchWinners, participate, authUsername,
-  ...props
+  canDeclareResults, ...props
 }) => {
   const { competitionId } = match.params;
   useEffect(
@@ -139,6 +144,16 @@ const CompetitionSingle = ({
             />
           )
         }
+        {
+          // Render declare winners button if allowed
+          canDeclareResults && (
+            <Link to={`/competitions/~create/declare-winners/${competition.id}`}>
+              <PrimaryButton style={{ width: 'fit-content', padding: '8px 24px' }}>
+                Declare Results
+              </PrimaryButton>
+            </Link>
+          )
+        }
 
         {/** Hashtag info */}
         <div className={styles.hashTagText}>
@@ -206,6 +221,7 @@ CompetitionSingle.propTypes = {
   participate: PropTypes.func.isRequired,
   authUsername: PropTypes.string,
   isPostsLoading: PropTypes.bool.isRequired,
+  canDeclareResults: PropTypes.bool.isRequired,
 };
 
 CompetitionSingle.defaultProps = {
@@ -218,6 +234,7 @@ const mapStateToProps = (state, ownProps) => ({
   competition: getCompetitionById(state, ownProps.match.params.competitionId),
   authUsername: getAuthUsername(state),
   isPostsLoading: isPostsLoading(state, ownProps.match.params.competitionId),
+  canDeclareResults: isWinnerDeclareAllowed(state, ownProps.match.params.competitionId),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(

--- a/src/competitions/Leaderboard/index.js
+++ b/src/competitions/Leaderboard/index.js
@@ -24,7 +24,7 @@ const WinnerList = Loadable({
  * @param {boolean} initialState The default state of toggle
  * @returns Array containing a boolean value and function to toggle it
  */
-const useToggle = (initialState = false) => {
+export const useToggle = (initialState = false) => {
   const [state, changeState] = useState(initialState);
   return [state, () => changeState(!state)];
 };

--- a/src/competitions/Leaderboard/reducer.js
+++ b/src/competitions/Leaderboard/reducer.js
@@ -1,4 +1,5 @@
 import { actionTypes } from './actions';
+import { getCompetitionsState } from '../reducer';
 
 const initialState = {
   loading: false,
@@ -36,7 +37,8 @@ export default (state = initialState, action) => {
 };
 
 // Selectors
-export const getCompetitionsLeaderboardState = state => state.competitionsLeaderboard;
+export const getCompetitionsLeaderboardState = state =>
+  getCompetitionsState(state).leaderboard;
 
 export const isFetching = (state) => {
   const leaderboardState = getCompetitionsLeaderboardState(state);

--- a/src/competitions/create/AnnouncementPost/actions.js
+++ b/src/competitions/create/AnnouncementPost/actions.js
@@ -128,7 +128,7 @@ export const registerAndCreatePost = (competitionId, announcementMode) =>
  */
 export const fillAnnouncementPost = (competitionId, mode) =>
   async (dispatch, getState, { haprampAPI }) => {
-    const realMode = mode === 'declare_winners' ? 'winners' : mode;
+    const realMode = mode === 'declare-winners' ? 'winners' : mode;
     const state = getState();
     const competition = getCompetitionById(state, competitionId);
     if (competition) {

--- a/src/competitions/create/AnnouncementPost/actions.js
+++ b/src/competitions/create/AnnouncementPost/actions.js
@@ -131,7 +131,9 @@ export const fillAnnouncementPost = (competitionId, mode) =>
     const realMode = mode === 'declare_winners' ? 'winners' : mode;
     const state = getState();
     const competition = getCompetitionById(state, competitionId);
-    dispatch(setTitle(competition.title));
+    if (competition) {
+      dispatch(setTitle(competition.title));
+    }
     return haprampAPI.v2.competitions.getCompetitionPostBody(competitionId, realMode)
       .then(result => dispatch(setPostContent(result.body)));
   };

--- a/src/competitions/create/AnnouncementPost/actions.js
+++ b/src/competitions/create/AnnouncementPost/actions.js
@@ -1,0 +1,111 @@
+import uniq from 'lodash/uniq';
+import { push } from 'connected-react-router';
+
+import { getPostContent, getTags, getTitle } from './reducer';
+import { getAuthUsername } from '../../../reducers/authUserReducer';
+import { getCompetitionById } from '../../reducer';
+
+export const baseName = '@competitions/create/announce';
+
+export const actionTypes = {
+  setPostContent: `${baseName}/setPostContent`,
+  setTags: `${baseName}/setTags`,
+  setTitle: `${baseName}/setTitle`,
+  registerAndCreatePost: {
+    init: `${baseName}/registerAndCreate/init`,
+    done: `${baseName}/registerAndCreate/done`,
+    error: `${baseName}/registerAndCreate/error`,
+  },
+};
+
+export const setPostContent = content => dispatch => dispatch({
+  type: actionTypes.setPostContent,
+  content,
+});
+
+export const setTitle = title => dispatch => dispatch({
+  type: actionTypes.setTitle,
+  title,
+});
+
+export const setTags = tags => dispatch => dispatch({
+  type: actionTypes.setTags,
+  tags: uniq(tags // Remove duplicates
+    .map(tag => tag.toLowerCase())
+    .filter(tag => tag.match(/^[a-z|A-Z]/))), // Should start with a character
+});
+
+export const registerAndCreatePost = (competitionId, announcementMode) =>
+  async (dispatch, getState, { haprampAPI, steemAPI, notify }) => {
+    const state = getState();
+    const tags = getTags(state);
+    const body = getPostContent(state);
+    const author = getAuthUsername(state);
+    const title = getTitle(state);
+
+    const fields = {
+      tags,
+      body,
+      author,
+      title,
+      competitionId,
+      announcementMode,
+    };
+
+    dispatch({
+      type: actionTypes.registerAndCreatePost.init,
+      ...fields,
+    });
+
+    const permlink = await steemAPI.createPermlink(title, author, '', '');
+
+    return steemAPI.sc2Operations.createPost(
+      author, body, tags, null, permlink,
+      title,
+    ).then(() => {
+      /**
+       * Post has been created, now register the permlink
+       * with backend
+       */
+      notify.success(`Post created on Steem with permlink: ${permlink}`);
+      return haprampAPI.v2.competitions
+        .registerAnnouncementPermlink(competitionId, announcementMode, author, permlink);
+    }).then((response) => {
+      /**
+       * Post created and permlink registered with backend.
+       * Redirect to the competition page
+       */
+      dispatch(push(`/competitions/${competitionId}`));
+      notify.success('Post created for competition');
+      return dispatch({
+        type: actionTypes.registerAndCreatePost.done,
+        response,
+        ...fields,
+      });
+    }).error((reason) => {
+      /**
+       * Error occured either while creating or while
+       * registering the post.
+       * If the post has been created, the user would
+       * get a message asking not to retry.
+       */
+      const errorText = 'There was some error registering the post. If already posted to Steem, do not retry and contact @the1ramp.';
+      console.error('[Unable to register post', reason, errorText);
+      notify.danger('There was some error registering the post. If already posted to Steem, do not retry and contact @the1ramp.');
+      return dispatch({
+        type: actionTypes.registerAndCreatePost.error,
+        reason,
+        ...fields,
+      });
+    });
+  };
+
+export const fillAnnouncementPost = (competitionId, mode) =>
+  async (dispatch, getState, { haprampAPI }) => {
+    const realMode = mode === 'declare_winners' ? 'winners' : mode;
+    const state = getState();
+    const competition = getCompetitionById(state, competitionId);
+    dispatch(setTitle(competition.title));
+    return haprampAPI.v2.competitions.getCompetitionPostBody(competitionId, realMode)
+      .then(result => dispatch(setPostContent(result.body)));
+  };

--- a/src/competitions/create/AnnouncementPost/actions.js
+++ b/src/competitions/create/AnnouncementPost/actions.js
@@ -18,16 +18,28 @@ export const actionTypes = {
   },
 };
 
+/**
+ * Sets content for the annoucnement blog
+ * @param {string} content Markdown body
+ */
 export const setPostContent = content => dispatch => dispatch({
   type: actionTypes.setPostContent,
   content,
 });
 
+/**
+ * Set's blog title
+ * @param {string} title Title
+ */
 export const setTitle = title => dispatch => dispatch({
   type: actionTypes.setTitle,
   title,
 });
 
+/**
+ * Sets tags for announcement blog
+ * @param {array} tags Array of tags
+ */
 export const setTags = tags => dispatch => dispatch({
   type: actionTypes.setTags,
   tags: uniq(tags // Remove duplicates
@@ -35,6 +47,13 @@ export const setTags = tags => dispatch => dispatch({
     .filter(tag => tag.match(/^[a-z|A-Z]/))), // Should start with a character
 });
 
+/**
+ * Registers a competition permlink with backend for
+ * given announcement mode and publishes the blog on
+ * Steem
+ * @param {string} competitionId Competition ID
+ * @param {string} announcementMode Mode for annoncement
+ */
 export const registerAndCreatePost = (competitionId, announcementMode) =>
   async (dispatch, getState, { haprampAPI, steemAPI, notify }) => {
     const state = getState();
@@ -59,6 +78,7 @@ export const registerAndCreatePost = (competitionId, announcementMode) =>
 
     const permlink = await steemAPI.createPermlink(title, author, '', '');
 
+    // Start creating post
     return steemAPI.sc2Operations.createPost(
       author, body, tags, null, permlink,
       title,
@@ -100,6 +120,12 @@ export const registerAndCreatePost = (competitionId, announcementMode) =>
     });
   };
 
+/**
+ * Fetches default body for a post annoucnement and
+ * populates the input area
+ * @param {string} competitionId Competition ID
+ * @param {string} mode Mode for announcement
+ */
 export const fillAnnouncementPost = (competitionId, mode) =>
   async (dispatch, getState, { haprampAPI }) => {
     const realMode = mode === 'declare_winners' ? 'winners' : mode;

--- a/src/competitions/create/AnnouncementPost/actions.js
+++ b/src/competitions/create/AnnouncementPost/actions.js
@@ -76,7 +76,7 @@ export const registerAndCreatePost = (competitionId, announcementMode) =>
        * Redirect to the competition page
        */
       dispatch(push(`/competitions/${competitionId}`));
-      notify.success('Post created for competition');
+      notify.success('Post registered for competition');
       return dispatch({
         type: actionTypes.registerAndCreatePost.done,
         response,

--- a/src/competitions/create/AnnouncementPost/index.js
+++ b/src/competitions/create/AnnouncementPost/index.js
@@ -23,10 +23,10 @@ import { getCompetitionById } from '../../actions';
 
 const getInstructionString = (mode, competition) => {
   const { title } = competition;
-  if (mode === 'declare_winners') {
+  if (mode === 'announce') {
     return `Publish the contest announcement blog for "${title}".`;
   }
-  if (mode === 'declare_winners') {
+  if (mode === 'declare-winners') {
     return `Publish the winner announcement blog for "${title}".`;
   }
   return 'Publish competition blog.';

--- a/src/competitions/create/AnnouncementPost/index.js
+++ b/src/competitions/create/AnnouncementPost/index.js
@@ -21,11 +21,23 @@ import {
 } from '../../reducer';
 import { getCompetitionById } from '../../actions';
 
+const getInstructionString = (mode, competition) => {
+  const { title } = competition;
+  if (mode === 'declare_winners') {
+    return `Publish the contest announcement blog for "${title}".`;
+  }
+  if (mode === 'declare_winners') {
+    return `Publish the winner announcement blog for "${title}".`;
+  }
+  return 'Publish competition blog.';
+};
+
 const AnnouncementPost = ({
   mode, competitionId, doesCompetitionExist,
   isAnnounceAllowed, fetchCompetition, postContent,
   setPostContent, tags, setTags, title, setTitle,
   fillAnnouncementPost, isRegistering, register,
+  competition,
 }) => {
   /**
    * Fetch competition and use loading variable
@@ -70,9 +82,9 @@ const AnnouncementPost = ({
    */
   return (
     <ViewContainer>
-      <div>
-        Writing {mode} post for competition with ID {competitionId}
-      </div>
+      <h2 style={{ padding: 24 }}>
+        {getInstructionString(mode, competition)}
+      </h2>
       <div>
         <Input
           placeholder="Title"
@@ -120,9 +132,11 @@ AnnouncementPost.propTypes = {
   fillAnnouncementPost: PropTypes.func.isRequired,
   isRegistering: PropTypes.bool.isRequired,
   register: PropTypes.func.isRequired,
+  competition: PropTypes.shape(),
 };
 
 AnnouncementPost.defaultProps = {
+  competition: {},
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/src/competitions/create/AnnouncementPost/index.js
+++ b/src/competitions/create/AnnouncementPost/index.js
@@ -1,16 +1,46 @@
-/**
- * - Fetch the competition.
- * - See if the current user is the competition owner
- * - If all the conditions are met, show the post editor
- */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import ViewContainer from '../../../components/ViewContainer';
+import MarkdownEditor from '../../../post/create/CreateArticle/MarkdownEditor';
+import TagsSelector from '../../../post/create/CreateArticle/ArticleNext/TagsSelector';
+import Input from '../../../components/input/Input';
+import PrimaryButton from '../../../components/buttons/PrimaryButton';
+
+import {
+  setPostContent as setContent, setTags as setPostTags,
+  setTitle as setPostTitle, fillAnnouncementPost as fillAnnouncement,
+  registerAndCreatePost,
+} from './actions';
+import { getPostContent, getTags, getTitle, isPostRegistering } from './reducer';
+import {
+  isCompetitionAvailable, isAnnounceAllowed as canAnnounce,
+  getCompetitionById as getCompetition,
+} from '../../reducer';
+import { getCompetitionById } from '../../actions';
 
 const AnnouncementPost = ({
-  mode, competitionId, loading, doesCompetitionExist,
-  isAnnounceAllowed,
+  mode, competitionId, doesCompetitionExist,
+  isAnnounceAllowed, fetchCompetition, postContent,
+  setPostContent, tags, setTags, title, setTitle,
+  fillAnnouncementPost, isRegistering, register,
 }) => {
+  /**
+   * Fetch competition and use loading variable
+   * to check if the action is complete
+   */
+  const [loading, setLoading] = useState(true);
+  useEffect(
+    () => {
+      setLoading(true);
+      fetchCompetition(competitionId)
+        .then(() => fillAnnouncementPost(competitionId, mode))
+        .finally(() => setLoading(false));
+    },
+    [competitionId],
+  );
   if (loading) {
     return (
       <ViewContainer>
@@ -18,6 +48,12 @@ const AnnouncementPost = ({
       </ViewContainer>
     );
   }
+
+  /**
+   * Now that the request for competition
+   * has been completed, check to see if we
+   * can see the editor for creating the post
+   */
   if (!doesCompetitionExist || !isAnnounceAllowed) {
     return (
       <ViewContainer>
@@ -25,13 +61,87 @@ const AnnouncementPost = ({
       </ViewContainer>
     );
   }
+
+  /**
+   * All good: the competition exists and the current user
+   * has proper permissions to make announcement posts
+   * for the competition
+   * Show the editor
+   */
   return (
     <ViewContainer>
       <div>
         Writing {mode} post for competition with ID {competitionId}
       </div>
+      <div>
+        <Input
+          placeholder="Title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          className="uk-margin-bottom"
+        />
+        <MarkdownEditor onChange={setPostContent} bodyMarkdown={postContent} />
+        <TagsSelector
+          tags={tags}
+          addTag={tag => setTags([...tags, tag])}
+          removeTag={tag => setTags(tags.filter(t => t !== tag))}
+          style={{ padding: 0, margin: '24px 0' }}
+        />
+      </div>
+      <div>
+        <PrimaryButton
+          onClick={() => register(competitionId, mode)}
+          disabled={isRegistering}
+          style={{
+            width: 'fit-content',
+            padding: '8px 24px',
+            marginLeft: 'auto',
+          }}
+        >
+          Publish and Register
+        </PrimaryButton>
+      </div>
     </ViewContainer>
   );
 };
 
-export default AnnouncementPost;
+AnnouncementPost.propTypes = {
+  mode: PropTypes.string.isRequired,
+  competitionId: PropTypes.string.isRequired,
+  doesCompetitionExist: PropTypes.bool.isRequired,
+  isAnnounceAllowed: PropTypes.bool.isRequired,
+  fetchCompetition: PropTypes.func.isRequired,
+  postContent: PropTypes.string.isRequired,
+  setPostContent: PropTypes.func.isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+  setTags: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  setTitle: PropTypes.func.isRequired,
+  fillAnnouncementPost: PropTypes.func.isRequired,
+  isRegistering: PropTypes.bool.isRequired,
+  register: PropTypes.func.isRequired,
+};
+
+AnnouncementPost.defaultProps = {
+};
+
+const mapStateToProps = (state, ownProps) => ({
+  doesCompetitionExist: isCompetitionAvailable(state, ownProps.competitionId),
+  isAnnounceAllowed: canAnnounce(state, ownProps.competitionId),
+  competition: getCompetition(state, ownProps.competitionId),
+  postContent: getPostContent(state),
+  tags: getTags(state),
+  title: getTitle(state),
+  isRegistering: isPostRegistering(state),
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  fetchCompetition: getCompetitionById,
+  setPostContent: setContent,
+  setTags: setPostTags,
+  setTitle: setPostTitle,
+  fillAnnouncementPost: fillAnnouncement,
+  register: registerAndCreatePost,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(AnnouncementPost);

--- a/src/competitions/create/AnnouncementPost/index.js
+++ b/src/competitions/create/AnnouncementPost/index.js
@@ -1,0 +1,37 @@
+/**
+ * - Fetch the competition.
+ * - See if the current user is the competition owner
+ * - If all the conditions are met, show the post editor
+ */
+import React from 'react';
+
+import ViewContainer from '../../../components/ViewContainer';
+
+const AnnouncementPost = ({
+  mode, competitionId, loading, doesCompetitionExist,
+  isAnnounceAllowed,
+}) => {
+  if (loading) {
+    return (
+      <ViewContainer>
+        Loading...
+      </ViewContainer>
+    );
+  }
+  if (!doesCompetitionExist || !isAnnounceAllowed) {
+    return (
+      <ViewContainer>
+        Competition not found or insufficient permission.
+      </ViewContainer>
+    );
+  }
+  return (
+    <ViewContainer>
+      <div>
+        Writing {mode} post for competition with ID {competitionId}
+      </div>
+    </ViewContainer>
+  );
+};
+
+export default AnnouncementPost;

--- a/src/competitions/create/AnnouncementPost/reducer.js
+++ b/src/competitions/create/AnnouncementPost/reducer.js
@@ -1,0 +1,67 @@
+import { actionTypes } from './actions';
+import { getAnnouncementPostState } from '../reducer';
+
+const initialState = {
+  content: '',
+  tags: [],
+  title: '',
+  register: {
+    loading: false,
+    error: null,
+  },
+};
+
+const announcePostReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case actionTypes.setPostContent:
+      return { ...state, content: action.content };
+
+    case actionTypes.setTags:
+      return { ...state, tags: action.tags };
+
+    case actionTypes.setTitle:
+      return { ...state, title: action.title };
+
+    case actionTypes.registerAndCreatePost.init:
+      return {
+        ...state,
+        register: {
+          ...state.register,
+          loading: true,
+        },
+      };
+
+    case actionTypes.registerAndCreatePost.done:
+      return {
+        ...state,
+        register: {
+          ...state.register,
+          loading: false,
+          error: null,
+        },
+      };
+
+    case actionTypes.registerAndCreatePost.error:
+      return {
+        ...state,
+        register: {
+          ...state.register,
+          loading: false,
+          error: action.reason,
+        },
+      };
+
+    default:
+      return state;
+  }
+};
+
+export default announcePostReducer;
+
+export const getPostContent = state => getAnnouncementPostState(state).content;
+
+export const getTags = state => getAnnouncementPostState(state).tags;
+
+export const getTitle = state => getAnnouncementPostState(state).title;
+
+export const isPostRegistering = state => getAnnouncementPostState(state).register.loading;

--- a/src/competitions/create/DeclareWinners/EntryList.js
+++ b/src/competitions/create/DeclareWinners/EntryList.js
@@ -1,0 +1,72 @@
+/**
+ * Renders entries for a competition with
+ * a way to assign ranks to them.
+ */
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
+
+import { getPostsForCompetition } from '../../actions';
+import {
+  getCompetitionPostPermlinks, isPostsLoading,
+} from '../../reducer';
+import RankAssigner from './RankAssigner';
+import PostLoading from '../../../post/PostLoading';
+import PostCard from '../../../post/PostCard';
+
+const EntryList = ({
+  competitionId, fetchCompetitionPosts, posts, loading,
+}) => {
+  useEffect(
+    () => {
+      fetchCompetitionPosts(competitionId);
+    },
+    [competitionId],
+  );
+
+  return (
+    <div className="uk-grid">
+      {
+        loading && (
+          <div className="uk-width-1-2@s">
+            <PostLoading />
+          </div>
+        )
+      }
+      {
+        posts.map(permlink => (
+          <div className="uk-width-1-2@s uk-margin-small-bottom" key={permlink}>
+            <PostCard
+              postPermlink={permlink}
+              border
+              maintainAspectRatio
+              style={{ border: '1px solid rgba(0, 0, 0, 0.12)' }}
+              className="uk-margin-remove-bottom"
+            />
+            <RankAssigner competitionId={competitionId} permlink={permlink} />
+          </div>
+        ))
+      }
+    </div>
+  );
+};
+
+EntryList.propTypes = {
+  competitionId: PropTypes.string.isRequired,
+  fetchCompetitionPosts: PropTypes.func.isRequired,
+  // posts is an array of full permlinks
+  posts: PropTypes.arrayOf(PropTypes.string).isRequired,
+  loading: PropTypes.bool.isRequired,
+};
+
+const mapStateToProps = (state, ownProps) => ({
+  posts: getCompetitionPostPermlinks(state, ownProps.competitionId),
+  loading: isPostsLoading(state, ownProps.competitionId),
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  fetchCompetitionPosts: getPostsForCompetition,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(EntryList);

--- a/src/competitions/create/DeclareWinners/RankAssigner.js
+++ b/src/competitions/create/DeclareWinners/RankAssigner.js
@@ -1,0 +1,95 @@
+/**
+ * Component to assign rank to an entry
+ * for a contest.
+ */
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+
+import {
+  setRank as setEntryRank,
+  unsetRank as unsetEntryRank,
+} from './actions';
+import { getAllRanks } from './reducer';
+import PrimaryButton from '../../../components/buttons/PrimaryButton';
+import DefaultButton from '../../../components/buttons/DefaultButton';
+
+const RankAssigner = ({
+  allRanks, permlink, setRank, competitionId,
+  unsetRank,
+}) => {
+  // Find out the rank data for current permlink
+  const myRank = allRanks.find(r => r.permlink === permlink);
+  if (myRank) {
+    return (
+      <PrimaryButton
+        style={{
+          background: 'black',
+          color: 'white',
+          borderRadius: 0,
+        }}
+        onClick={() => unsetRank(competitionId, myRank.rank)}
+      >
+        Rank: {myRank.rank} ({myRank.prize})
+        <span style={{ fontFamily: 'monospace', marginLeft: 8 }}>x</span>
+      </PrimaryButton>
+    );
+  }
+
+  const [open, setOpen] = useState(false);
+
+  // Find out the ranks which are not alloted to any posts
+  const unassignedRanks = allRanks.filter(r => !r.permlink);
+
+  return (
+    <div>
+      <PrimaryButton onClick={() => setOpen(!open)} style={{ borderRadius: 0 }}>
+        Assign Rank
+      </PrimaryButton>
+      {
+        open && (
+          <div>
+            {
+              unassignedRanks.map(r => (
+                <DefaultButton
+                  key={r.rank}
+                  onClick={() => {
+                    setOpen(false);
+                    setRank(competitionId, permlink, r.rank);
+                  }}
+                  style={{ borderRadius: 0 }}
+                >
+                  {r.rank} ({r.prize})
+                </DefaultButton>
+              ))
+            }
+          </div>
+        )
+      }
+    </div>
+  );
+};
+
+RankAssigner.propTypes = {
+  allRanks: PropTypes.arrayOf(PropTypes.shape),
+  permlink: PropTypes.string.isRequired,
+  setRank: PropTypes.func.isRequired,
+  competitionId: PropTypes.string.isRequired,
+  unsetRank: PropTypes.func.isRequired,
+};
+
+RankAssigner.defaultProps = {
+  allRanks: [],
+};
+
+const mapStateToProps = (state, ownProps) => ({
+  allRanks: getAllRanks(state, ownProps.competitionId),
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  setRank: setEntryRank,
+  unsetRank: unsetEntryRank,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(RankAssigner);

--- a/src/competitions/create/DeclareWinners/RankAssigner.js
+++ b/src/competitions/create/DeclareWinners/RankAssigner.js
@@ -19,6 +19,8 @@ const RankAssigner = ({
   allRanks, permlink, setRank, competitionId,
   unsetRank,
 }) => {
+  const [open, setOpen] = useState(false);
+
   // Find out the rank data for current permlink
   const myRank = allRanks.find(r => r.permlink === permlink);
   if (myRank) {
@@ -37,8 +39,6 @@ const RankAssigner = ({
     );
   }
 
-  const [open, setOpen] = useState(false);
-
   // Find out the ranks which are not alloted to any posts
   const unassignedRanks = allRanks.filter(r => !r.permlink);
 
@@ -49,6 +49,7 @@ const RankAssigner = ({
       </PrimaryButton>
       {
         open && (
+          // Render buttons for assigning the available ranks the permlink
           <div>
             {
               unassignedRanks.map(r => (

--- a/src/competitions/create/DeclareWinners/actions.js
+++ b/src/competitions/create/DeclareWinners/actions.js
@@ -1,14 +1,70 @@
+import { push } from 'connected-react-router';
+
+import { getAllRanks } from './reducer';
+
 export const baseName = '@competitions/create/declareWinners';
 
 export const actionTypes = {
   setRank: `${baseName}/setRank`,
   unsetRank: `${baseName}/unsetRank`,
+  declareWinners: {
+    init: `${baseName}/declareWinners/init`,
+    done: `${baseName}/declareWinners/done`,
+    error: `${baseName}/declareWinners/error`,
+  },
 };
 
+/**
+ * Assigns rank to an entry
+ * @param {string} competitionId Competition ID
+ * @param {string} permlink Full permlink for the entry
+ * @param {number} rank Rank for the entry
+ */
 export const setRank = (competitionId, permlink, rank) => dispatch => dispatch({
   type: actionTypes.setRank, permlink, rank, competitionId,
 });
 
+/**
+ * Removed permlink from an entry
+ * @param {string} competitionId Competition ID
+ * @param {number} rank Rank to unset
+ */
 export const unsetRank = (competitionId, rank) => dispatch => dispatch({
   type: actionTypes.unsetRank, rank, competitionId,
 });
+
+/**
+ * Declares winners for a competition given it's ID
+ * @param {string} competitionId Competition ID
+ */
+export const declareWinners = competitionId => (dispatch, getState, { haprampAPI }) => {
+  const state = getState();
+  const ranks = getAllRanks(state, competitionId);
+  dispatch({ type: actionTypes.declareWinners.init, competitionId, ranks });
+
+  // Set the winners for the competition
+  return haprampAPI.v2.competitions.setWinners(competitionId, ranks)
+    // Announce results for the competition
+    .then(() => haprampAPI.v2.competitions.announceResults(competitionId))
+    .then((result) => {
+      /**
+       * Winners announced, move to post announcement form
+       * for declaring winners
+       */
+      dispatch(push(`/competitions/~create/post/${competitionId}/declare_winners`));
+      return dispatch({
+        type: actionTypes.declareWinners.done,
+        result,
+        competitionId,
+        ranks,
+      });
+    }).catch((reason) => {
+      console.error('Failed to declare winners', reason);
+      return dispatch({
+        type: actionTypes.declareWinners.error,
+        reason,
+        competitionId,
+        ranks,
+      });
+    });
+};

--- a/src/competitions/create/DeclareWinners/actions.js
+++ b/src/competitions/create/DeclareWinners/actions.js
@@ -1,0 +1,14 @@
+export const baseName = '@competitions/create/declareWinners';
+
+export const actionTypes = {
+  setRank: `${baseName}/setRank`,
+  unsetRank: `${baseName}/unsetRank`,
+};
+
+export const setRank = (competitionId, permlink, rank) => dispatch => dispatch({
+  type: actionTypes.setRank, permlink, rank, competitionId,
+});
+
+export const unsetRank = (competitionId, rank) => dispatch => dispatch({
+  type: actionTypes.unsetRank, rank, competitionId,
+});

--- a/src/competitions/create/DeclareWinners/index.js
+++ b/src/competitions/create/DeclareWinners/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
+import EntryList from './EntryList';
 import ViewContainer from '../../../components/ViewContainer';
 import { getCompetitionById } from '../../actions';
 import { isAnnounceAllowed as isCompetitionAnnounceAllowed } from '../../reducer';
@@ -10,6 +11,10 @@ import { isAnnounceAllowed as isCompetitionAnnounceAllowed } from '../../reducer
 const DeclareWinners = ({
   competitionId, fetchCompetition, isAnnounceAllowed,
 }) => {
+  /**
+   * Load competition details and check if we
+   * are allowed to announce results
+   */
   const [loading, setLoading] = useState(true);
   useEffect(
     () => {
@@ -37,9 +42,16 @@ const DeclareWinners = ({
     );
   }
 
+  /**
+   * All conditions met, we can now declare results.
+   * Show a list of entries for the competition
+   */
   return (
     <ViewContainer>
-      Declaring winners for {competitionId}.
+      <div>
+        Declaring winners for {competitionId}.
+      </div>
+      <EntryList competitionId={competitionId} />
     </ViewContainer>
   );
 };

--- a/src/competitions/create/DeclareWinners/index.js
+++ b/src/competitions/create/DeclareWinners/index.js
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import ViewContainer from '../../../components/ViewContainer';
+import { getCompetitionById } from '../../actions';
+import { isAnnounceAllowed as isCompetitionAnnounceAllowed } from '../../reducer';
+
+const DeclareWinners = ({
+  competitionId, fetchCompetition, isAnnounceAllowed,
+}) => {
+  const [loading, setLoading] = useState(true);
+  useEffect(
+    () => {
+      setLoading(true);
+      fetchCompetition(competitionId)
+        .finally(() => setLoading(false));
+      return () => setLoading(false);
+    },
+    [competitionId],
+  );
+
+  if (loading) {
+    return (
+      <ViewContainer>
+        Loading...
+      </ViewContainer>
+    );
+  }
+
+  if (!isAnnounceAllowed) {
+    return (
+      <ViewContainer>
+        Competition not found, insufficient permissions or winner declaration not allowed.
+      </ViewContainer>
+    );
+  }
+
+  return (
+    <ViewContainer>
+      Declaring winners for {competitionId}.
+    </ViewContainer>
+  );
+};
+
+DeclareWinners.propTypes = {
+  competitionId: PropTypes.string.isRequired,
+  fetchCompetition: PropTypes.func.isRequired,
+  isAnnounceAllowed: PropTypes.bool.isRequired,
+};
+
+const mapStateToProps = (state, ownProps) => ({
+  isAnnounceAllowed: isCompetitionAnnounceAllowed(state, ownProps.competitionId),
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  fetchCompetition: getCompetitionById,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(DeclareWinners);

--- a/src/competitions/create/DeclareWinners/index.js
+++ b/src/competitions/create/DeclareWinners/index.js
@@ -12,12 +12,12 @@ import {
   isDeclareInProgress,
   isDeclarePossible as isAllRanksSelected,
 } from './reducer';
-import { isWinnerDeclareAllowed } from '../../reducer';
+import { isWinnerDeclareAllowed, getCompetitionById as getCompetition } from '../../reducer';
 import PrimaryButton from '../../../components/buttons/PrimaryButton';
 
 const DeclareWinners = ({
   competitionId, fetchCompetition, isAnnounceAllowed, isDeclarePossible,
-  isDeclaring, declareWinners,
+  isDeclaring, declareWinners, competition,
 }) => {
   /**
    * Load competition details and check if we
@@ -58,7 +58,7 @@ const DeclareWinners = ({
   return (
     <ViewContainer>
       <div>
-        Declaring winners for {competitionId}.
+        Declaring winners for {`"${competition.title}"`}.
       </div>
       <EntryList competitionId={competitionId} />
       {
@@ -66,7 +66,7 @@ const DeclareWinners = ({
           <ConfirmationModal
             confirmActive={!isDeclaring}
             cancelActive={!isDeclaring}
-            confirmContent="Create and Continue"
+            confirmContent="Declare and Continue"
             cancelContent="Cancel"
             onConfirm={() => declareWinners(competitionId)}
             onCancel={() => setConfirmation(false)}
@@ -103,12 +103,18 @@ DeclareWinners.propTypes = {
   isDeclarePossible: PropTypes.bool.isRequired,
   isDeclaring: PropTypes.bool.isRequired,
   declareWinners: PropTypes.func.isRequired,
+  competition: PropTypes.shape(),
+};
+
+DeclareWinners.defaultProps = {
+  competition: {},
 };
 
 const mapStateToProps = (state, ownProps) => ({
   isAnnounceAllowed: isWinnerDeclareAllowed(state, ownProps.competitionId),
   isDeclarePossible: isAllRanksSelected(state, ownProps.competitionId),
   isDeclaring: isDeclareInProgress(state, ownProps.competitionId),
+  competition: getCompetition(state, ownProps.competitionId),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/src/competitions/create/DeclareWinners/index.js
+++ b/src/competitions/create/DeclareWinners/index.js
@@ -8,10 +8,10 @@ import ViewContainer from '../../../components/ViewContainer';
 import { getCompetitionById } from '../../actions';
 import { declareWinners as declareCompetitionWinners } from './actions';
 import {
-  isDeclarePossible as isWinnersDeclarePossible,
   isDeclareInProgress,
-  isRankAssignPossible,
+  isDeclarePossible as isAllRanksSelected,
 } from './reducer';
+import { isWinnerDeclareAllowed } from '../../reducer';
 import PrimaryButton from '../../../components/buttons/PrimaryButton';
 
 const DeclareWinners = ({
@@ -86,8 +86,8 @@ DeclareWinners.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-  isAnnounceAllowed: isRankAssignPossible(state, ownProps.competitionId),
-  isDeclarePossible: isWinnersDeclarePossible(state, ownProps.competitionId),
+  isAnnounceAllowed: isWinnerDeclareAllowed(state, ownProps.competitionId),
+  isDeclarePossible: isAllRanksSelected(state, ownProps.competitionId),
   isDeclaring: isDeclareInProgress(state, ownProps.competitionId),
 });
 

--- a/src/competitions/create/DeclareWinners/index.js
+++ b/src/competitions/create/DeclareWinners/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 
 import EntryList from './EntryList';
 import ViewContainer from '../../../components/ViewContainer';
+import ConfirmationModal from '../../../components/ConfirmationModal';
 import { getCompetitionById } from '../../actions';
 import { declareWinners as declareCompetitionWinners } from './actions';
 import {
@@ -23,6 +24,7 @@ const DeclareWinners = ({
    * are allowed to announce results
    */
   const [loading, setLoading] = useState(true);
+  const [confirmation, setConfirmation] = useState(false);
   useEffect(
     () => {
       setLoading(true);
@@ -59,17 +61,35 @@ const DeclareWinners = ({
         Declaring winners for {competitionId}.
       </div>
       <EntryList competitionId={competitionId} />
+      {
+        confirmation && (
+          <ConfirmationModal
+            confirmActive={!isDeclaring}
+            cancelActive={!isDeclaring}
+            confirmContent="Create and Continue"
+            cancelContent="Cancel"
+            onConfirm={() => declareWinners(competitionId)}
+            onCancel={() => setConfirmation(false)}
+          >
+            <h2>Declare winners and continue?</h2>
+            <p>
+              Continue to declare the winners. On the next step,
+              you can edit and publish a blog to announce the winners.
+            </p>
+          </ConfirmationModal>
+        )
+      }
       <div>
         <PrimaryButton
           disabled={!isDeclarePossible && !isDeclaring}
-          onClick={() => declareWinners(competitionId)}
+          onClick={() => setConfirmation(true)}
           style={{
             width: 'fit-content',
             padding: '8px 24px',
             marginLeft: 'auto',
           }}
         >
-          Declare Results and Continue
+          Next
         </PrimaryButton>
       </div>
     </ViewContainer>

--- a/src/competitions/create/DeclareWinners/index.js
+++ b/src/competitions/create/DeclareWinners/index.js
@@ -6,10 +6,12 @@ import { connect } from 'react-redux';
 import EntryList from './EntryList';
 import ViewContainer from '../../../components/ViewContainer';
 import { getCompetitionById } from '../../actions';
+import { isDeclarePossible as isWinnersDeclarePossible } from './reducer';
 import { isAnnounceAllowed as isCompetitionAnnounceAllowed } from '../../reducer';
+import PrimaryButton from '../../../components/buttons/PrimaryButton';
 
 const DeclareWinners = ({
-  competitionId, fetchCompetition, isAnnounceAllowed,
+  competitionId, fetchCompetition, isAnnounceAllowed, isDeclarePossible,
 }) => {
   /**
    * Load competition details and check if we
@@ -52,6 +54,18 @@ const DeclareWinners = ({
         Declaring winners for {competitionId}.
       </div>
       <EntryList competitionId={competitionId} />
+      <div>
+        <PrimaryButton
+          disabled={!isDeclarePossible}
+          style={{
+            width: 'fit-content',
+            padding: '8px 24px',
+            marginLeft: 'auto',
+          }}
+        >
+          Declare Results and Continue
+        </PrimaryButton>
+      </div>
     </ViewContainer>
   );
 };
@@ -60,10 +74,12 @@ DeclareWinners.propTypes = {
   competitionId: PropTypes.string.isRequired,
   fetchCompetition: PropTypes.func.isRequired,
   isAnnounceAllowed: PropTypes.bool.isRequired,
+  isDeclarePossible: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => ({
   isAnnounceAllowed: isCompetitionAnnounceAllowed(state, ownProps.competitionId),
+  isDeclarePossible: isWinnersDeclarePossible(state, ownProps.competitionId),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/src/competitions/create/DeclareWinners/index.js
+++ b/src/competitions/create/DeclareWinners/index.js
@@ -6,12 +6,17 @@ import { connect } from 'react-redux';
 import EntryList from './EntryList';
 import ViewContainer from '../../../components/ViewContainer';
 import { getCompetitionById } from '../../actions';
-import { isDeclarePossible as isWinnersDeclarePossible } from './reducer';
-import { isAnnounceAllowed as isCompetitionAnnounceAllowed } from '../../reducer';
+import { declareWinners as declareCompetitionWinners } from './actions';
+import {
+  isDeclarePossible as isWinnersDeclarePossible,
+  isDeclareInProgress,
+  isRankAssignPossible,
+} from './reducer';
 import PrimaryButton from '../../../components/buttons/PrimaryButton';
 
 const DeclareWinners = ({
   competitionId, fetchCompetition, isAnnounceAllowed, isDeclarePossible,
+  isDeclaring, declareWinners,
 }) => {
   /**
    * Load competition details and check if we
@@ -56,7 +61,8 @@ const DeclareWinners = ({
       <EntryList competitionId={competitionId} />
       <div>
         <PrimaryButton
-          disabled={!isDeclarePossible}
+          disabled={!isDeclarePossible && !isDeclaring}
+          onClick={() => declareWinners(competitionId)}
           style={{
             width: 'fit-content',
             padding: '8px 24px',
@@ -75,15 +81,19 @@ DeclareWinners.propTypes = {
   fetchCompetition: PropTypes.func.isRequired,
   isAnnounceAllowed: PropTypes.bool.isRequired,
   isDeclarePossible: PropTypes.bool.isRequired,
+  isDeclaring: PropTypes.bool.isRequired,
+  declareWinners: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => ({
-  isAnnounceAllowed: isCompetitionAnnounceAllowed(state, ownProps.competitionId),
+  isAnnounceAllowed: isRankAssignPossible(state, ownProps.competitionId),
   isDeclarePossible: isWinnersDeclarePossible(state, ownProps.competitionId),
+  isDeclaring: isDeclareInProgress(state, ownProps.competitionId),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   fetchCompetition: getCompetitionById,
+  declareWinners: declareCompetitionWinners,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(DeclareWinners);

--- a/src/competitions/create/DeclareWinners/reducer.js
+++ b/src/competitions/create/DeclareWinners/reducer.js
@@ -1,11 +1,24 @@
+import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { actionTypes } from './actions';
-import { getCompetitionById } from '../../reducer';
+import { getCompetitionById, isAnnounceAllowed, isWinnersDeclared } from '../../reducer';
 import { getDeclareWinnersState } from '../reducer';
 
 const initialState = {
   byId: {},
+};
+
+/**
+ * This is what all the competitions look like
+ * initially in the store
+ */
+const defaultInitialObject = {
+  ranks: {},
+  declare: {
+    loading: false,
+    error: null,
+  },
 };
 
 const DeclareWinnersReducer = (state = initialState, action) => {
@@ -14,15 +27,43 @@ const DeclareWinnersReducer = (state = initialState, action) => {
     case actionTypes.setRank:
       newState = cloneDeep(state);
       if (!newState[action.competitionId]) {
-        newState[action.competitionId] = {};
+        newState[action.competitionId] = { ...defaultInitialObject };
       }
-      newState[action.competitionId][action.rank] = action.permlink;
+      newState[action.competitionId].ranks[action.rank] = action.permlink;
       return newState;
 
     case actionTypes.unsetRank:
       newState = cloneDeep(state);
-      delete newState[action.competitionId][action.rank];
+      delete newState[action.competitionId].ranks[action.rank];
       return newState;
+
+    // START Handling actions related to winner declaration
+    case actionTypes.declareWinners.init:
+      newState = cloneDeep(state);
+      if (!newState[action.competitionId]) {
+        newState[action.competitionId] = { ...defaultInitialObject };
+      }
+      newState[action.competitionId].declare.loading = true;
+      return newState;
+
+    case actionTypes.declareWinners.done:
+      newState = cloneDeep(state);
+      if (!newState[action.competitionId]) {
+        newState[action.competitionId] = { ...defaultInitialObject };
+      }
+      newState[action.competitionId].declare.loading = false;
+      newState[action.competitionId].declare.error = null;
+      return newState;
+
+    case actionTypes.declareWinners.error:
+      newState = cloneDeep(state);
+      if (!newState[action.competitionId]) {
+        newState[action.competitionId] = { ...defaultInitialObject };
+      }
+      newState[action.competitionId].declare.loading = false;
+      newState[action.competitionId].declare.error = action.reason;
+      return newState;
+    // END Handling actions related to winner declaration
 
     default:
       return state;
@@ -31,22 +72,57 @@ const DeclareWinnersReducer = (state = initialState, action) => {
 
 export default DeclareWinnersReducer;
 
+/**
+ * Returns assigned ranks for a competition given it's ID
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
 export const getAssignedRanksForCompetition = (state, competitionId) =>
-  getDeclareWinnersState(state)[competitionId] || {};
+  get(getDeclareWinnersState(state), `${competitionId}.ranks`, {});
 
+/**
+ * Returns all ranks for a competition including assignment
+ * related information if any
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
 export const getAllRanks = (state, competitionId) => {
   const competition = getCompetitionById(state, competitionId);
   if (!competition) {
+    // No such competition
     return null;
   }
   const assignedRanks = getAssignedRanksForCompetition(state, competitionId);
   return competition.prizes.map((prize, idx) => ({
     rank: idx + 1,
     prize,
+    // include the post assigned to the rank
     permlink: assignedRanks[idx + 1] || undefined,
   }));
 };
 
+/**
+ * Returns true if it is possible for the user to assign
+ * ranks to a competition, given it's ID
+ * - Current user is the creator for the competition
+ * - Results for the contest are not already declared
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
+export const isRankAssignPossible = (state, competitionId) => {
+  if (!isAnnounceAllowed(state, competitionId) || isWinnersDeclared(state, competitionId)) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * Checks if it's possible to proceed with declaring
+ * winners for a competition
+ * - All the prizes are assiged to the posts
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
 export const isDeclarePossible = (state, competitionId) => {
   const ranks = getAllRanks(state, competitionId);
   if (!ranks) {
@@ -54,3 +130,12 @@ export const isDeclarePossible = (state, competitionId) => {
   }
   return ranks.filter(r => !r.permlink).length === 0; // All permlinks present
 };
+
+/**
+ * Returns true if winner declaration for a competition is in progress,
+ * given its ID
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
+export const isDeclareInProgress = (state, competitionId) =>
+  get(getDeclareWinnersState(state), `${competitionId}.declare.loading`, false);

--- a/src/competitions/create/DeclareWinners/reducer.js
+++ b/src/competitions/create/DeclareWinners/reducer.js
@@ -2,7 +2,7 @@ import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { actionTypes } from './actions';
-import { getCompetitionById, isAnnounceAllowed, isWinnersDeclared } from '../../reducer';
+import { getCompetitionById } from '../../reducer';
 import { getDeclareWinnersState } from '../reducer';
 
 const initialState = {
@@ -99,21 +99,6 @@ export const getAllRanks = (state, competitionId) => {
     // include the post assigned to the rank
     permlink: assignedRanks[idx + 1] || undefined,
   }));
-};
-
-/**
- * Returns true if it is possible for the user to assign
- * ranks to a competition, given it's ID
- * - Current user is the creator for the competition
- * - Results for the contest are not already declared
- * @param {object} state Current redux state
- * @param {string} competitionId Competition ID
- */
-export const isRankAssignPossible = (state, competitionId) => {
-  if (!isAnnounceAllowed(state, competitionId) || isWinnersDeclared(state, competitionId)) {
-    return false;
-  }
-  return true;
 };
 
 /**

--- a/src/competitions/create/DeclareWinners/reducer.js
+++ b/src/competitions/create/DeclareWinners/reducer.js
@@ -1,0 +1,45 @@
+import cloneDeep from 'lodash/cloneDeep';
+
+import { actionTypes } from './actions';
+import { getCompetitionById } from '../../reducer';
+import { getDeclareWinnersState } from '../reducer';
+
+const initialState = {
+  byId: {},
+};
+
+const DeclareWinnersReducer = (state = initialState, action) => {
+  let newState;
+  switch (action.type) {
+    case actionTypes.setRank:
+      newState = cloneDeep(state);
+      if (!newState[action.competitionId]) {
+        newState[action.competitionId] = {};
+      }
+      newState[action.competitionId][action.rank] = action.permlink;
+      return newState;
+
+    case actionTypes.unsetRank:
+      newState = cloneDeep(state);
+      delete newState[action.competitionId][action.rank];
+      return newState;
+
+    default:
+      return state;
+  }
+};
+
+export default DeclareWinnersReducer;
+
+export const getAssignedRanksForCompetition = (state, competitionId) =>
+  getDeclareWinnersState(state)[competitionId] || {};
+
+export const getAllRanks = (state, competitionId) => {
+  const competition = getCompetitionById(state, competitionId);
+  const assignedRanks = getAssignedRanksForCompetition(state, competitionId);
+  return competition.prizes.map((prize, idx) => ({
+    rank: idx + 1,
+    prize,
+    permlink: assignedRanks[idx + 1] || undefined,
+  }));
+};

--- a/src/competitions/create/DeclareWinners/reducer.js
+++ b/src/competitions/create/DeclareWinners/reducer.js
@@ -36,10 +36,21 @@ export const getAssignedRanksForCompetition = (state, competitionId) =>
 
 export const getAllRanks = (state, competitionId) => {
   const competition = getCompetitionById(state, competitionId);
+  if (!competition) {
+    return null;
+  }
   const assignedRanks = getAssignedRanksForCompetition(state, competitionId);
   return competition.prizes.map((prize, idx) => ({
     rank: idx + 1,
     prize,
     permlink: assignedRanks[idx + 1] || undefined,
   }));
+};
+
+export const isDeclarePossible = (state, competitionId) => {
+  const ranks = getAllRanks(state, competitionId);
+  if (!ranks) {
+    return false;
+  }
+  return ranks.filter(r => !r.permlink).length === 0; // All permlinks present
 };

--- a/src/competitions/create/newCompetition/Description.js
+++ b/src/competitions/create/newCompetition/Description.js
@@ -41,7 +41,7 @@ const NewCompetitionDescription = ({
     <div className={styles.bottomBar}>
       <Link to="/competitions/~create/details">
         <PrimaryButton className={styles.button}>
-          CONTINUE
+          NEXT
         </PrimaryButton>
       </Link>
     </div>

--- a/src/competitions/create/newCompetition/Description.js
+++ b/src/competitions/create/newCompetition/Description.js
@@ -1,27 +1,41 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import PrimaryButton from '../../../components/buttons/PrimaryButton';
 import ViewContainer from '../../../components/ViewContainer';
 import Input from '../../../components/input/Input';
 import TextArea from '../../../components/input/TextArea';
 import styles from './styles.scss';
+import { getNewCompetitionField } from './reducer';
+import { changeField } from './actions';
 
-const NewCompetitionDescription = () => (
+const NewCompetitionDescription = ({
+  name, description, rules,
+  setName, setDescription, setRules,
+}) => (
   <ViewContainer>
     <div>
       <Input
         placeholder="Competition Name"
         className="uk-form-large uk-margin-large-bottom"
+        value={name}
+        onChange={setName}
       />
       <TextArea
         placeholder="Description"
         className="uk-margin-small-bottom"
         rows={2}
+        value={description}
+        onChange={setDescription}
       />
       <TextArea
         placeholder="Rules"
         rows={2}
+        value={rules}
+        onChange={setRules}
       />
     </div>
     <div className={styles.bottomBar}>
@@ -34,4 +48,25 @@ const NewCompetitionDescription = () => (
   </ViewContainer>
 );
 
-export default NewCompetitionDescription;
+NewCompetitionDescription.propTypes = {
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  rules: PropTypes.string.isRequired,
+  setName: PropTypes.func.isRequired,
+  setDescription: PropTypes.func.isRequired,
+  setRules: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = state => ({
+  name: getNewCompetitionField(state, 'name'),
+  description: getNewCompetitionField(state, 'description'),
+  rules: getNewCompetitionField(state, 'rules'),
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  setName: event => changeField('name', event.target.value),
+  setDescription: event => changeField('description', event.target.value),
+  setRules: event => changeField('rules', event.target.value),
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(NewCompetitionDescription);

--- a/src/competitions/create/newCompetition/Description.js
+++ b/src/competitions/create/newCompetition/Description.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import PrimaryButton from '../../../components/buttons/PrimaryButton';
+import ViewContainer from '../../../components/ViewContainer';
+import Input from '../../../components/input/Input';
+import TextArea from '../../../components/input/TextArea';
+import styles from './styles.scss';
+
+const NewCompetitionDescription = () => (
+  <ViewContainer>
+    <div>
+      <Input
+        placeholder="Competition Name"
+        className="uk-form-large uk-margin-large-bottom"
+      />
+      <TextArea
+        placeholder="Description"
+        className="uk-margin-small-bottom"
+        rows={2}
+      />
+      <TextArea
+        placeholder="Rules"
+        rows={2}
+      />
+    </div>
+    <div className={styles.bottomBar}>
+      <Link to="/competitions/~create/details">
+        <PrimaryButton className={styles.button}>
+          CONTINUE
+        </PrimaryButton>
+      </Link>
+    </div>
+  </ViewContainer>
+);
+
+export default NewCompetitionDescription;

--- a/src/competitions/create/newCompetition/Details.js
+++ b/src/competitions/create/newCompetition/Details.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -13,211 +13,234 @@ import Icon from '../../../icons/Icon';
 import DefaultButton from '../../../components/buttons/DefaultButton';
 import GrayButton from '../../../components/buttons/GrayButton';
 import PrimaryButton from '../../../components/buttons/PrimaryButton';
+import ConfirmationModal from '../../../components/ConfirmationModal';
 import { getNewCompetitionField, isCompetitionCreating } from './reducer';
 import { changeField, createCompetition } from './actions';
 import { uploadImage } from '../../../post/create/CreateArticle/actions';
 import styles from './styles.scss';
 import { getSumPrize } from '../../utils';
 
-const NewCompetitionDetails = props => (
-  <ViewContainer style={{ paddingBottom: 80 }}>
-    <InterestsSelector
-      backgroundColor="white"
-      interestBackground="#f5f5f5"
-      selectedCommunities={props.interests}
-      onClick={(community) => {
-        /**
-         * Handle logic when an interest is selected
-         */
-        const { id } = community;
-        let newInterests;
-        if (props.interests.indexOf(id) >= 0) { // Already selected
-          newInterests = props.interests.filter(iId => iId !== id);
-          return props.changeField('interests', newInterests);
-        } else if (props.interests.length < 3) { // Can select more interests
-          newInterests = props.interests.concat([id]);
-          return props.changeField('interests', newInterests);
-        }
-        return null;
-      }}
-    />
-
-    {/* TagSelector can also be used as username selector for judges with appropriate logic */}
-    <TagSelector
-      tags={props.judges}
-      addTag={judge => props.changeField('judges', uniq([...props.judges, judge.toLowerCase()]))}
-      removeTag={judge => props.changeField('judges', props.judges.filter(t => t !== judge))}
-      PrefixComponent={UserAvatar}
-      disabled={props.judges.length === 3}
-      // Decide the props to pass to UserAvatar component
-      prefixPropsSelector={judge => ({ username: judge, size: 'small', style: { width: 28, marginRight: 8 } })}
-      headerText="Judges"
-    />
-
-    {/* Time range selector */}
-    <div className={styles.dateRangeContainer}>
-      <div className={styles.header}>Timings</div>
-      <div className="uk-grid uk-margin-top">
-        {/* Start time */}
-        <div className="uk-flex">
-          <div>Starts At</div>
-          <div className={`uk-margin-small-left ${styles.inputsContainer}`}>
-            <div className="uk-flex">
-              <input
-                type="date"
-                min={new Date().toISOString().substr(0, 10)}
-                value={props.startDate.date}
-                onChange={event => props.changeField('startDate', { ...props.startDate, date: event.target.value })}
-              />
-              <Icon name="calender" />
-            </div>
-            <div className="uk-flex">
-              <input
-                type="time"
-                min={new Date().toISOString().substr(11, 5)}
-                value={props.startDate.time}
-                onChange={event => props.changeField('startDate', { ...props.startDate, time: event.target.value })}
-              />
-              <Icon name="clock" />
-            </div>
-          </div>
-        </div>
-        {/* End time */}
-        <div className="uk-flex">
-          <div className={styles.label}>Ends At</div>
-          <div className={`uk-margin-small-left ${styles.inputsContainer}`}>
-            <div className="uk-flex">
-              <input
-                type="date"
-                // Should not be before start date
-                min={props.startDate.date || new Date().toISOString().substr(0, 10)}
-                value={props.endDate.date}
-                onChange={event => props.changeField('endDate', { ...props.endDate, date: event.target.value })}
-              />
-              <Icon name="calender" />
-            </div>
-            <div className="uk-flex">
-              <input
-                type="time"
-                min={new Date().toISOString().substr(11, 5)}
-                value={props.endDate.time}
-                onChange={event => props.changeField('endDate', { ...props.endDate, time: event.target.value })}
-              />
-              <Icon name="clock" />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    {/* For entering prizes */}
-    <div className={styles.prizesEntry}>
-      <div className={styles.header}>Prizes</div>
-      <div className="uk-margin-top">
-        <div className="uk-flex uk-margin-small-bottom">
-          <div className={styles.prizeLabel}>Total:</div>
-          <div style={{ padding: '0 8px' }}>{getSumPrize(props.prizes.filter(p => p.length))}</div>
-        </div>
-        <div className="uk-flex uk-margin-small-bottom">
-          <div className={styles.prizeLabel}>
-            1<sup>st</sup> Prize:
-            <span className={styles.importantMark}>*</span>
-          </div>
-          <div>
-            <input
-              value={props.prizes[0]}
-              onChange={(event) => {
-                const newPrizes = [...props.prizes];
-                newPrizes[0] = event.target.value;
-                props.changeField('prizes', newPrizes);
-              }}
-            />
-          </div>
-        </div>
-        <div className="uk-flex uk-margin-small-bottom">
-          <div className={styles.prizeLabel}>
-            3<sup>nd</sup> Prize:
-          </div>
-          <div>
-            <input
-              value={props.prizes[1]}
-              onChange={(event) => {
-                const newPrizes = [...props.prizes];
-                newPrizes[1] = event.target.value;
-                props.changeField('prizes', newPrizes);
-              }}
-            />
-          </div>
-        </div>
-        <div className="uk-flex uk-margin-small-bottom">
-          <div className={styles.prizeLabel}>
-            3<sup>rd</sup> Prize:
-          </div>
-          <div>
-            <input
-              value={props.prizes[2]}
-              onChange={(event) => {
-                const newPrizes = [...props.prizes];
-                newPrizes[2] = event.target.value;
-                props.changeField('prizes', newPrizes);
-              }}
-              className="uk-margin-small-bottom"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div className={styles.imageContainer}>
-      <div className={`${styles.header} uk-margin-small-bottom`}>Competition Banner</div>
-      {
-        props.image && (
-          <img
-            src={props.image}
-            alt=""
-          />
-        )
-      }
-      <GrayButton
-        className={styles.button}
-        onClick={() => {
-          const input = document.createElement('input');
-          input.type = 'file';
-          input.accept = 'image/*';
-          input.addEventListener('change', () => {
-            // Event listener for when an image is selected
-            if (input.files.length > 0) {
-              // Take just the first one if multiple images are selected
-              const [file] = input.files;
-              props.uploadImage(file)
-                .then(({ url }) => {
-                  props.changeField('image', url);
-                });
-            }
-          });
-          input.click();
+const NewCompetitionDetails = (props) => {
+  const [confirmModalOpen, setConfirmModalOpen] = useState(false);
+  return (
+    <ViewContainer style={{ paddingBottom: 80 }}>
+      <InterestsSelector
+        backgroundColor="white"
+        interestBackground="#f5f5f5"
+        selectedCommunities={props.interests}
+        onClick={(community) => {
+          /**
+           * Handle logic when an interest is selected
+           */
+          const { id } = community;
+          let newInterests;
+          if (props.interests.indexOf(id) >= 0) { // Already selected
+            newInterests = props.interests.filter(iId => iId !== id);
+            return props.changeField('interests', newInterests);
+          } else if (props.interests.length < 3) { // Can select more interests
+            newInterests = props.interests.concat([id]);
+            return props.changeField('interests', newInterests);
+          }
+          return null;
         }}
-      >
-        Choose Image
-      </GrayButton>
-    </div>
+      />
 
-    <div className={styles.bottomBar}>
-      <Link to="/competitions/~create">
-        <DefaultButton className={styles.button}>
-          GO BACK
-        </DefaultButton>
-      </Link>
-      <PrimaryButton
-        className={styles.button}
-        onClick={props.createCompetition}
-        disabled={props.isCompetitionCreating}
-      >
-        PUBLISH
-      </PrimaryButton>
-    </div>
-  </ViewContainer>
-);
+      {/* TagSelector can also be used as username selector for judges with appropriate logic */}
+      <TagSelector
+        tags={props.judges}
+        addTag={judge => props.changeField('judges', uniq([...props.judges, judge.toLowerCase()]))}
+        removeTag={judge => props.changeField('judges', props.judges.filter(t => t !== judge))}
+        PrefixComponent={UserAvatar}
+        disabled={props.judges.length === 3}
+        // Decide the props to pass to UserAvatar component
+        prefixPropsSelector={judge => ({ username: judge, size: 'small', style: { width: 28, marginRight: 8 } })}
+        headerText="Judges"
+      />
+
+      {/* Time range selector */}
+      <div className={styles.dateRangeContainer}>
+        <div className={styles.header}>Timings</div>
+        <div className="uk-grid uk-margin-top">
+          {/* Start time */}
+          <div className="uk-flex">
+            <div>Starts At</div>
+            <div className={`uk-margin-small-left ${styles.inputsContainer}`}>
+              <div className="uk-flex">
+                <input
+                  type="date"
+                  min={new Date().toISOString().substr(0, 10)}
+                  value={props.startDate.date}
+                  onChange={event => props.changeField('startDate', { ...props.startDate, date: event.target.value })}
+                />
+                <Icon name="calender" />
+              </div>
+              <div className="uk-flex">
+                <input
+                  type="time"
+                  min={new Date().toISOString().substr(11, 5)}
+                  value={props.startDate.time}
+                  onChange={event => props.changeField('startDate', { ...props.startDate, time: event.target.value })}
+                />
+                <Icon name="clock" />
+              </div>
+            </div>
+          </div>
+          {/* End time */}
+          <div className="uk-flex">
+            <div className={styles.label}>Ends At</div>
+            <div className={`uk-margin-small-left ${styles.inputsContainer}`}>
+              <div className="uk-flex">
+                <input
+                  type="date"
+                  // Should not be before start date
+                  min={props.startDate.date || new Date().toISOString().substr(0, 10)}
+                  value={props.endDate.date}
+                  onChange={event => props.changeField('endDate', { ...props.endDate, date: event.target.value })}
+                />
+                <Icon name="calender" />
+              </div>
+              <div className="uk-flex">
+                <input
+                  type="time"
+                  min={new Date().toISOString().substr(11, 5)}
+                  value={props.endDate.time}
+                  onChange={event => props.changeField('endDate', { ...props.endDate, time: event.target.value })}
+                />
+                <Icon name="clock" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* For entering prizes */}
+      <div className={styles.prizesEntry}>
+        <div className={styles.header}>Prizes</div>
+        <div className="uk-margin-top">
+          <div className="uk-flex uk-margin-small-bottom">
+            <div className={styles.prizeLabel}>Total:</div>
+            <div style={{ padding: '0 8px' }}>{getSumPrize(props.prizes.filter(p => p.length))}</div>
+          </div>
+          <div className="uk-flex uk-margin-small-bottom">
+            <div className={styles.prizeLabel}>
+              1<sup>st</sup> Prize:
+            <span className={styles.importantMark}>*</span>
+            </div>
+            <div>
+              <input
+                value={props.prizes[0]}
+                onChange={(event) => {
+                  const newPrizes = [...props.prizes];
+                  newPrizes[0] = event.target.value;
+                  props.changeField('prizes', newPrizes);
+                }}
+              />
+            </div>
+          </div>
+          <div className="uk-flex uk-margin-small-bottom">
+            <div className={styles.prizeLabel}>
+              3<sup>nd</sup> Prize:
+            </div>
+            <div>
+              <input
+                value={props.prizes[1]}
+                onChange={(event) => {
+                  const newPrizes = [...props.prizes];
+                  newPrizes[1] = event.target.value;
+                  props.changeField('prizes', newPrizes);
+                }}
+              />
+            </div>
+          </div>
+          <div className="uk-flex uk-margin-small-bottom">
+            <div className={styles.prizeLabel}>
+              3<sup>rd</sup> Prize:
+            </div>
+            <div>
+              <input
+                value={props.prizes[2]}
+                onChange={(event) => {
+                  const newPrizes = [...props.prizes];
+                  newPrizes[2] = event.target.value;
+                  props.changeField('prizes', newPrizes);
+                }}
+                className="uk-margin-small-bottom"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.imageContainer}>
+        <div className={`${styles.header} uk-margin-small-bottom`}>Competition Banner</div>
+        {
+          props.image && (
+            <img
+              src={props.image}
+              alt=""
+            />
+          )
+        }
+        <GrayButton
+          className={styles.button}
+          onClick={() => {
+            const input = document.createElement('input');
+            input.type = 'file';
+            input.accept = 'image/*';
+            input.addEventListener('change', () => {
+              // Event listener for when an image is selected
+              if (input.files.length > 0) {
+                // Take just the first one if multiple images are selected
+                const [file] = input.files;
+                props.uploadImage(file)
+                  .then(({ url }) => {
+                    props.changeField('image', url);
+                  });
+              }
+            });
+            input.click();
+          }}
+        >
+          Choose Image
+        </GrayButton>
+      </div>
+
+      <div className={styles.bottomBar}>
+        <Link to="/competitions/~create">
+          <DefaultButton className={styles.button}>
+            GO BACK
+          </DefaultButton>
+        </Link>
+        {
+          confirmModalOpen && (
+            <ConfirmationModal
+              confirmActive={!props.isCompetitionCreating}
+              cancelActive={!props.isCompetitionCreating}
+              confirmContent="Create and Continue"
+              cancelContent="Cancel"
+              onConfirm={props.createCompetition}
+              onCancel={() => setConfirmModalOpen(false)}
+            >
+              <h2>Create new contest and continue?</h2>
+              <p>
+                Continue to create the contest. On the next step,
+                you can edit and publish a blog to announce this
+                contest.
+              </p>
+            </ConfirmationModal>
+          )
+        }
+        <PrimaryButton
+          className={styles.button}
+          onClick={() => setConfirmModalOpen(true)}
+          disabled={confirmModalOpen}
+        >
+          NEXT
+        </PrimaryButton>
+      </div>
+    </ViewContainer>
+  );
+};
 
 NewCompetitionDetails.propTypes = {
   changeField: PropTypes.func.isRequired,

--- a/src/competitions/create/newCompetition/Details.js
+++ b/src/competitions/create/newCompetition/Details.js
@@ -55,6 +55,7 @@ const NewCompetitionDetails = (props) => {
         // Decide the props to pass to UserAvatar component
         prefixPropsSelector={judge => ({ username: judge, size: 'small', style: { width: 28, marginRight: 8 } })}
         headerText="Judges"
+        style={{ margin: '0 0 8px 0' }}
       />
 
       {/* Time range selector */}
@@ -178,6 +179,7 @@ const NewCompetitionDetails = (props) => {
             <img
               src={props.image}
               alt=""
+              className="uk-margin-small-bottom"
             />
           )
         }

--- a/src/competitions/create/newCompetition/Details.js
+++ b/src/competitions/create/newCompetition/Details.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import ViewContainer from '../../../components/ViewContainer';
+import InterestsSelector from '../../../post/create/CreatePost/CommunitySelector';
+import TagSelector from '../../../post/create/CreateArticle/ArticleNext/TagsSelector';
+import Icon from '../../../icons/Icon';
+import DefaultButton from '../../../components/buttons/DefaultButton';
+import GrayButton from '../../../components/buttons/GrayButton';
+import PrimaryButton from '../../../components/buttons/PrimaryButton';
+import styles from './styles.scss';
+
+const NewCompetitionDetails = () => (
+  <ViewContainer>
+    <InterestsSelector
+      backgroundColor="white"
+      interestBackground="#f5f5f5"
+      selectedCommunities={[1, 2]}
+    />
+    <TagSelector
+      tags={['lol']}
+    />
+
+    {/* Time range selector */}
+    <div className={styles.dateRangeContainer}>
+      <div className={styles.header}>Timings</div>
+      <div className="uk-grid uk-margin-top">
+        {/* Start time */}
+        <div className="uk-flex">
+          <div>Starts At</div>
+          <div className={`uk-margin-small-left ${styles.inputsContainer}`}>
+            <div className="uk-flex">
+              <input type="date" min={new Date().toISOString().substr(0, 10)} />
+              <Icon name="calender" />
+            </div>
+            <div className="uk-flex">
+              <input type="time" min={new Date().toISOString().substr(11, 5)} />
+              <Icon name="clock" />
+            </div>
+          </div>
+        </div>
+        {/* End time */}
+        <div className="uk-flex">
+          <div className={styles.label}>Ends At</div>
+          <div className={`uk-margin-small-left ${styles.inputsContainer}`}>
+            <div className="uk-flex">
+              <input type="date" min={new Date().toISOString().substr(0, 10)} />
+              <Icon name="calender" />
+            </div>
+            <div className="uk-flex">
+              <input type="time" min={new Date().toISOString().substr(11, 5)} />
+              <Icon name="clock" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {/* For entering prizes */}
+    <div className={styles.prizesEntry}>
+      <div className={styles.header}>Prizes</div>
+      <div className="uk-margin-top">
+        <div className="uk-flex uk-margin-small-bottom">
+          <div className={styles.prizeLabel}>
+            1<sup>st</sup> Prize:
+            <span className={styles.importantMark}>*</span>
+          </div>
+          <div>
+            <input />
+          </div>
+        </div>
+        <div className="uk-flex uk-margin-small-bottom">
+          <div className={styles.prizeLabel}>
+            3<sup>nd</sup> Prize:
+          </div>
+          <div>
+            <input />
+          </div>
+        </div>
+        <div className="uk-flex uk-margin-small-bottom">
+          <div className={styles.prizeLabel}>
+            3<sup>rd</sup> Prize:
+          </div>
+          <div>
+            <input />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div className={styles.imageContainer}>
+      <div className={`${styles.header} uk-margin-small-bottom`}>Competition Banner</div>
+      <GrayButton className={styles.button}>
+        Choose Image
+      </GrayButton>
+    </div>
+
+    <div className={styles.bottomBar}>
+      <Link to="/competitions/~create">
+        <DefaultButton className={styles.button}>
+          GO BACK
+        </DefaultButton>
+      </Link>
+      <PrimaryButton className={styles.button}>
+        PUBLISH
+      </PrimaryButton>
+    </div>
+  </ViewContainer>
+);
+
+export default NewCompetitionDetails;

--- a/src/competitions/create/newCompetition/Details.js
+++ b/src/competitions/create/newCompetition/Details.js
@@ -1,5 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import uniq from 'lodash/uniq';
+import PropTypes from 'prop-types';
 
 import ViewContainer from '../../../components/ViewContainer';
 import InterestsSelector from '../../../post/create/CreatePost/CommunitySelector';
@@ -8,17 +12,38 @@ import Icon from '../../../icons/Icon';
 import DefaultButton from '../../../components/buttons/DefaultButton';
 import GrayButton from '../../../components/buttons/GrayButton';
 import PrimaryButton from '../../../components/buttons/PrimaryButton';
+import { getNewCompetitionField } from './reducer';
+import { changeField } from './actions';
+import { uploadImage } from '../../../post/create/CreateArticle/actions';
 import styles from './styles.scss';
+import { getSumPrize } from '../../utils';
 
-const NewCompetitionDetails = () => (
-  <ViewContainer>
+const NewCompetitionDetails = props => (
+  <ViewContainer style={{ paddingBottom: 80 }}>
     <InterestsSelector
       backgroundColor="white"
       interestBackground="#f5f5f5"
-      selectedCommunities={[1, 2]}
+      selectedCommunities={props.interests}
+      onClick={(community) => {
+        /**
+         * Handle logic when an interest is selected
+         */
+        const { id } = community;
+        let newInterests;
+        if (props.interests.indexOf(id) >= 0) { // Already selected
+          newInterests = props.interests.filter(iId => iId !== id);
+          return props.changeField('interests', newInterests);
+        } else if (props.interests.length < 3) { // Can select more interests
+          newInterests = props.interests.concat([id]);
+          return props.changeField('interests', newInterests);
+        }
+        return null;
+      }}
     />
     <TagSelector
-      tags={['lol']}
+      tags={props.tags}
+      addTag={tag => props.changeField('tags', uniq([...props.tags, tag.toLowerCase()]))}
+      removeTag={tag => props.changeField('tags', props.tags.filter(t => t !== tag))}
     />
 
     {/* Time range selector */}
@@ -30,11 +55,21 @@ const NewCompetitionDetails = () => (
           <div>Starts At</div>
           <div className={`uk-margin-small-left ${styles.inputsContainer}`}>
             <div className="uk-flex">
-              <input type="date" min={new Date().toISOString().substr(0, 10)} />
+              <input
+                type="date"
+                min={new Date().toISOString().substr(0, 10)}
+                value={props.startDate.date}
+                onChange={event => props.changeField('startDate', { ...props.startDate, date: event.target.value })}
+              />
               <Icon name="calender" />
             </div>
             <div className="uk-flex">
-              <input type="time" min={new Date().toISOString().substr(11, 5)} />
+              <input
+                type="time"
+                min={new Date().toISOString().substr(11, 5)}
+                value={props.startDate.time}
+                onChange={event => props.changeField('startDate', { ...props.startDate, time: event.target.value })}
+              />
               <Icon name="clock" />
             </div>
           </div>
@@ -44,11 +79,22 @@ const NewCompetitionDetails = () => (
           <div className={styles.label}>Ends At</div>
           <div className={`uk-margin-small-left ${styles.inputsContainer}`}>
             <div className="uk-flex">
-              <input type="date" min={new Date().toISOString().substr(0, 10)} />
+              <input
+                type="date"
+                // Should not be before start date
+                min={props.startDate.date || new Date().toISOString().substr(0, 10)}
+                value={props.endDate.date}
+                onChange={event => props.changeField('endDate', { ...props.endDate, date: event.target.value })}
+              />
               <Icon name="calender" />
             </div>
             <div className="uk-flex">
-              <input type="time" min={new Date().toISOString().substr(11, 5)} />
+              <input
+                type="time"
+                min={new Date().toISOString().substr(11, 5)}
+                value={props.endDate.time}
+                onChange={event => props.changeField('endDate', { ...props.endDate, time: event.target.value })}
+              />
               <Icon name="clock" />
             </div>
           </div>
@@ -61,12 +107,23 @@ const NewCompetitionDetails = () => (
       <div className={styles.header}>Prizes</div>
       <div className="uk-margin-top">
         <div className="uk-flex uk-margin-small-bottom">
+          <div className={styles.prizeLabel}>Total:</div>
+          <div style={{ padding: '0 8px' }}>{getSumPrize(props.prizes.filter(p => p.length))}</div>
+        </div>
+        <div className="uk-flex uk-margin-small-bottom">
           <div className={styles.prizeLabel}>
             1<sup>st</sup> Prize:
             <span className={styles.importantMark}>*</span>
           </div>
           <div>
-            <input />
+            <input
+              value={props.prizes[0]}
+              onChange={(event) => {
+                const newPrizes = [...props.prizes];
+                newPrizes[0] = event.target.value;
+                props.changeField('prizes', newPrizes);
+              }}
+            />
           </div>
         </div>
         <div className="uk-flex uk-margin-small-bottom">
@@ -74,7 +131,14 @@ const NewCompetitionDetails = () => (
             3<sup>nd</sup> Prize:
           </div>
           <div>
-            <input />
+            <input
+              value={props.prizes[1]}
+              onChange={(event) => {
+                const newPrizes = [...props.prizes];
+                newPrizes[1] = event.target.value;
+                props.changeField('prizes', newPrizes);
+              }}
+            />
           </div>
         </div>
         <div className="uk-flex uk-margin-small-bottom">
@@ -82,7 +146,15 @@ const NewCompetitionDetails = () => (
             3<sup>rd</sup> Prize:
           </div>
           <div>
-            <input />
+            <input
+              value={props.prizes[2]}
+              onChange={(event) => {
+                const newPrizes = [...props.prizes];
+                newPrizes[2] = event.target.value;
+                props.changeField('prizes', newPrizes);
+              }}
+              className="uk-margin-small-bottom"
+            />
           </div>
         </div>
       </div>
@@ -90,7 +162,32 @@ const NewCompetitionDetails = () => (
 
     <div className={styles.imageContainer}>
       <div className={`${styles.header} uk-margin-small-bottom`}>Competition Banner</div>
-      <GrayButton className={styles.button}>
+      {
+        props.image && (
+          <img
+            src={props.image}
+            alt=""
+          />
+        )
+      }
+      <GrayButton
+        className={styles.button}
+        onClick={() => {
+          const input = document.createElement('input');
+          input.type = 'file';
+          input.accept = 'image/*';
+          input.addEventListener('change', () => {
+            if (input.files.length > 0) {
+              const [file] = input.files;
+              props.uploadImage(file)
+                .then(({ url }) => {
+                  props.changeField('image', url);
+                });
+            }
+          });
+          input.click();
+        }}
+      >
         Choose Image
       </GrayButton>
     </div>
@@ -108,4 +205,35 @@ const NewCompetitionDetails = () => (
   </ViewContainer>
 );
 
-export default NewCompetitionDetails;
+NewCompetitionDetails.propTypes = {
+  changeField: PropTypes.func.isRequired,
+  interests: PropTypes.arrayOf(PropTypes.number).isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+  startDate: PropTypes.shape({
+    date: PropTypes.string,
+    time: PropTypes.string,
+  }).isRequired,
+  endDate: PropTypes.shape({
+    date: PropTypes.string,
+    time: PropTypes.string,
+  }).isRequired,
+  prizes: PropTypes.arrayOf(PropTypes.string).isRequired,
+  image: PropTypes.string.isRequired,
+  uploadImage: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = state => ({
+  tags: getNewCompetitionField(state, 'tags'),
+  interests: getNewCompetitionField(state, 'interests'),
+  startDate: getNewCompetitionField(state, 'startDate'),
+  endDate: getNewCompetitionField(state, 'endDate'),
+  prizes: getNewCompetitionField(state, 'prizes'),
+  image: getNewCompetitionField(state, 'image'),
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators(
+  { changeField, uploadImage },
+  dispatch,
+);
+
+export default connect(mapStateToProps, mapDispatchToProps)(NewCompetitionDetails);

--- a/src/competitions/create/newCompetition/Details.js
+++ b/src/competitions/create/newCompetition/Details.js
@@ -1,4 +1,3 @@
-// TODO: Judges
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
@@ -6,6 +5,7 @@ import { connect } from 'react-redux';
 import uniq from 'lodash/uniq';
 import PropTypes from 'prop-types';
 
+import UserAvatar from '../../../components/UserAvatar';
 import ViewContainer from '../../../components/ViewContainer';
 import InterestsSelector from '../../../post/create/CreatePost/CommunitySelector';
 import TagSelector from '../../../post/create/CreateArticle/ArticleNext/TagsSelector';
@@ -13,8 +13,8 @@ import Icon from '../../../icons/Icon';
 import DefaultButton from '../../../components/buttons/DefaultButton';
 import GrayButton from '../../../components/buttons/GrayButton';
 import PrimaryButton from '../../../components/buttons/PrimaryButton';
-import { getNewCompetitionField } from './reducer';
-import { changeField } from './actions';
+import { getNewCompetitionField, isCompetitionCreating } from './reducer';
+import { changeField, createCompetition } from './actions';
 import { uploadImage } from '../../../post/create/CreateArticle/actions';
 import styles from './styles.scss';
 import { getSumPrize } from '../../utils';
@@ -45,6 +45,18 @@ const NewCompetitionDetails = props => (
       tags={props.tags}
       addTag={tag => props.changeField('tags', uniq([...props.tags, tag.toLowerCase()]))}
       removeTag={tag => props.changeField('tags', props.tags.filter(t => t !== tag))}
+    />
+
+    {/* TagSelector can also be used as username selector for judges with appropriate logic */}
+    <TagSelector
+      tags={props.judges}
+      addTag={judge => props.changeField('judges', uniq([...props.judges, judge.toLowerCase()]))}
+      removeTag={judge => props.changeField('judges', props.judges.filter(t => t !== judge))}
+      PrefixComponent={UserAvatar}
+      disabled={props.judges.length === 3}
+      // Decide the props to pass to UserAvatar component
+      prefixPropsSelector={judge => ({ username: judge, size: 'small', style: { width: 28, marginRight: 8 } })}
+      headerText="Judges"
     />
 
     {/* Time range selector */}
@@ -201,7 +213,11 @@ const NewCompetitionDetails = props => (
           GO BACK
         </DefaultButton>
       </Link>
-      <PrimaryButton className={styles.button}>
+      <PrimaryButton
+        className={styles.button}
+        onClick={props.createCompetition}
+        disabled={props.isCompetitionCreating}
+      >
         PUBLISH
       </PrimaryButton>
     </div>
@@ -221,8 +237,11 @@ NewCompetitionDetails.propTypes = {
     time: PropTypes.string,
   }).isRequired,
   prizes: PropTypes.arrayOf(PropTypes.string).isRequired,
+  judges: PropTypes.arrayOf(PropTypes.string).isRequired,
   image: PropTypes.string.isRequired,
   uploadImage: PropTypes.func.isRequired,
+  createCompetition: PropTypes.func.isRequired,
+  isCompetitionCreating: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -232,10 +251,12 @@ const mapStateToProps = state => ({
   endDate: getNewCompetitionField(state, 'endDate'),
   prizes: getNewCompetitionField(state, 'prizes'),
   image: getNewCompetitionField(state, 'image'),
+  judges: getNewCompetitionField(state, 'judges'),
+  isCompetitionCreating: isCompetitionCreating(state),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(
-  { changeField, uploadImage },
+  { changeField, uploadImage, createCompetition },
   dispatch,
 );
 

--- a/src/competitions/create/newCompetition/Details.js
+++ b/src/competitions/create/newCompetition/Details.js
@@ -60,7 +60,7 @@ const NewCompetitionDetails = (props) => {
 
       {/* Time range selector */}
       <div className={styles.dateRangeContainer}>
-        <div className={styles.header}>Timings</div>
+        <div className={styles.header}>Timings (24 hour format)</div>
         <div className="uk-grid uk-margin-top">
           {/* Start time */}
           <div className="uk-flex">

--- a/src/competitions/create/newCompetition/Details.js
+++ b/src/competitions/create/newCompetition/Details.js
@@ -1,3 +1,4 @@
+// TODO: Judges
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
@@ -177,7 +178,9 @@ const NewCompetitionDetails = props => (
           input.type = 'file';
           input.accept = 'image/*';
           input.addEventListener('change', () => {
+            // Event listener for when an image is selected
             if (input.files.length > 0) {
+              // Take just the first one if multiple images are selected
               const [file] = input.files;
               props.uploadImage(file)
                 .then(({ url }) => {

--- a/src/competitions/create/newCompetition/Details.js
+++ b/src/competitions/create/newCompetition/Details.js
@@ -41,11 +41,6 @@ const NewCompetitionDetails = props => (
         return null;
       }}
     />
-    <TagSelector
-      tags={props.tags}
-      addTag={tag => props.changeField('tags', uniq([...props.tags, tag.toLowerCase()]))}
-      removeTag={tag => props.changeField('tags', props.tags.filter(t => t !== tag))}
-    />
 
     {/* TagSelector can also be used as username selector for judges with appropriate logic */}
     <TagSelector
@@ -227,7 +222,6 @@ const NewCompetitionDetails = props => (
 NewCompetitionDetails.propTypes = {
   changeField: PropTypes.func.isRequired,
   interests: PropTypes.arrayOf(PropTypes.number).isRequired,
-  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
   startDate: PropTypes.shape({
     date: PropTypes.string,
     time: PropTypes.string,
@@ -245,7 +239,6 @@ NewCompetitionDetails.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  tags: getNewCompetitionField(state, 'tags'),
   interests: getNewCompetitionField(state, 'interests'),
   startDate: getNewCompetitionField(state, 'startDate'),
   endDate: getNewCompetitionField(state, 'endDate'),

--- a/src/competitions/create/newCompetition/actions.js
+++ b/src/competitions/create/newCompetition/actions.js
@@ -1,0 +1,9 @@
+export const baseName = '@competitions/create/newCompetition';
+
+export const actionTypes = {
+  changeField: `${baseName}/changeField`,
+};
+
+export const changeField = (field, value) => dispatch => dispatch({
+  type: actionTypes.changeField, field, value,
+});

--- a/src/competitions/create/newCompetition/actions.js
+++ b/src/competitions/create/newCompetition/actions.js
@@ -1,9 +1,137 @@
+import { getNewCompetitionField } from './reducer';
+
 export const baseName = '@competitions/create/newCompetition';
 
 export const actionTypes = {
   changeField: `${baseName}/changeField`,
+  createCompetition: {
+    init: `${baseName}/createCompetition/init`,
+    done: `${baseName}/createCompetition/done`,
+    error: `${baseName}/createCompetition/error`,
+  },
 };
 
 export const changeField = (field, value) => dispatch => dispatch({
   type: actionTypes.changeField, field, value,
 });
+
+export const createCompetition = () => (dispatch, getState, { haprampAPI }) => {
+  const state = getState();
+
+  const name = getNewCompetitionField(state, 'name');
+  const description = getNewCompetitionField(state, 'description');
+  const rules = getNewCompetitionField(state, 'rules');
+  const tags = getNewCompetitionField(state, 'tags');
+  const interests = getNewCompetitionField(state, 'interests');
+  const startDateObj = getNewCompetitionField(state, 'startDate');
+  const endDateObj = getNewCompetitionField(state, 'endDate');
+  const prizes = getNewCompetitionField(state, 'prizes').filter(p => p.length > 0);
+  const image = getNewCompetitionField(state, 'image');
+  const judges = getNewCompetitionField(state, 'judges');
+
+  const fields = {
+    name,
+    description,
+    rules,
+    tags,
+    interests,
+    startDateObj,
+    endDateObj,
+    prizes,
+    image,
+    judges,
+  };
+
+  dispatch({
+    type: actionTypes.createCompetition.init,
+    fields,
+  });
+
+  // Process dates
+  let startDate;
+  let endDate;
+  try {
+    startDate = new Date(`${startDateObj.data}T${startDateObj.time}`);
+    endDate = new Date(`${endDateObj.data}T${endDateObj.time}`);
+  } catch (error) {
+    return dispatch({
+      type: actionTypes.createCompetition.error,
+      reason: new Error(`Invalid dates entered: ${error}`),
+    });
+  }
+
+  /**
+   * Validation for the data present
+   */
+  // Name, description and rules can't be empty
+  if (
+    name.length === 0
+    || description.length === 0
+    || rules.length === 0
+  ) {
+    return dispatch({
+      type: actionTypes.createCompetition.error,
+      reason: new Error('Name, description or rules are required'),
+    });
+  }
+  // There should be 1 to 3 interests
+  if (
+    interests.length < 1
+    || interests.length > 3
+  ) {
+    return dispatch({
+      type: actionTypes.createCompetition.error,
+      reason: new Error('Please select 1 to 3 communities'),
+    });
+  }
+  // There should be 1 - 3 judges
+  if (
+    judges.length < 1
+    || judges.length > 3
+  ) {
+    return dispatch({
+      type: actionTypes.createCompetition.error,
+      reason: new Error('There shold be 1 to 3 judges'),
+    });
+  }
+  // Validation for dates
+  const now = new Date();
+  if (
+    startDate < now
+    || endDate <= startDate
+  ) {
+    return dispatch({
+      type: actionTypes.createCompetition.error,
+      reason: new Error("Invalid dates: Competitions can't start in the past and the end date can't be before start date"),
+    });
+  }
+
+  // Create the contest at backend
+  return haprampAPI.v2.competitions.createCompetition({
+    image,
+    title: name,
+    description,
+    starts_at: startDate.toISOString(),
+    ends_at: endDate.toISOString(),
+    rules,
+    communities: interests,
+    judge_usernames: judges,
+  }).then(({ id }) => {
+    /**
+     * TODO: Insert action to navigate to competition
+     * announcement post creation page
+     */
+    dispatch();
+    return dispatch({
+      type: actionTypes.createCompetition.done,
+      fields,
+      id,
+    });
+  }).catch((reason) => {
+    console.error('[Create Competition] Error creating competition', reason);
+    return dispatch({
+      type: actionTypes.createCompetition.error,
+      reason,
+    });
+  });
+};

--- a/src/competitions/create/newCompetition/actions.js
+++ b/src/competitions/create/newCompetition/actions.js
@@ -1,3 +1,5 @@
+import { push } from 'connected-react-router';
+
 import { getNewCompetitionField } from './reducer';
 
 export const baseName = '@competitions/create/newCompetition';
@@ -21,7 +23,6 @@ export const createCompetition = () => (dispatch, getState, { haprampAPI, notify
   const name = getNewCompetitionField(state, 'name');
   const description = getNewCompetitionField(state, 'description');
   const rules = getNewCompetitionField(state, 'rules');
-  const tags = getNewCompetitionField(state, 'tags');
   const interests = getNewCompetitionField(state, 'interests');
   const startDateObj = getNewCompetitionField(state, 'startDate');
   const endDateObj = getNewCompetitionField(state, 'endDate');
@@ -33,7 +34,6 @@ export const createCompetition = () => (dispatch, getState, { haprampAPI, notify
     name,
     description,
     rules,
-    tags,
     interests,
     startDateObj,
     endDateObj,
@@ -117,11 +117,10 @@ export const createCompetition = () => (dispatch, getState, { haprampAPI, notify
     judge_usernames: judges,
     prizes,
   }).then(({ id }) => {
-    /**
-     * TODO: Insert action to navigate to competition
-     * announcement post creation page
-     */
-    dispatch({
+    notify.success('Competition created!');
+    notify.info('Please write a post to announce your competition on Steem');
+    dispatch(push(`/competitions/~create/post/${id}/announce`));
+    return dispatch({
       type: actionTypes.createCompetition.done,
       fields,
       id,

--- a/src/competitions/create/newCompetition/actions.js
+++ b/src/competitions/create/newCompetition/actions.js
@@ -118,7 +118,6 @@ export const createCompetition = () => (dispatch, getState, { haprampAPI, notify
     prizes,
   }).then(({ id }) => {
     notify.success('Competition created!');
-    notify.info('Please write a post to announce your competition on Steem');
     dispatch(push(`/competitions/~create/post/${id}/announce`));
     return dispatch({
       type: actionTypes.createCompetition.done,

--- a/src/competitions/create/newCompetition/reducer.js
+++ b/src/competitions/create/newCompetition/reducer.js
@@ -1,0 +1,43 @@
+import { actionTypes } from './actions';
+import { getNewCompetitionState } from '../reducer';
+
+const initialState = {
+  name: '',
+  description: '',
+  rules: '',
+  tags: [],
+  interests: [],
+  startDate: {
+    date: '',
+    time: '',
+  },
+  endDate: {
+    date: '',
+    time: '',
+  },
+  prizes: [
+    '',
+    '',
+    '',
+  ],
+  image: null,
+};
+
+const newCompetitionReducer = (state = initialState, action) => {
+  const { field, value } = action;
+  let newState;
+  switch (action.type) {
+    case actionTypes.changeField:
+      newState = { ...state };
+      newState[field] = value;
+      return newState;
+
+    default:
+      return state;
+  }
+};
+
+export default newCompetitionReducer;
+
+// Selector
+export const getNewCompetitionField = (state, field) => getNewCompetitionState(state)[field];

--- a/src/competitions/create/newCompetition/reducer.js
+++ b/src/competitions/create/newCompetition/reducer.js
@@ -5,7 +5,6 @@ const initialState = {
   name: '',
   description: '',
   rules: '',
-  tags: [],
   interests: [],
   startDate: {
     date: '',

--- a/src/competitions/create/newCompetition/reducer.js
+++ b/src/competitions/create/newCompetition/reducer.js
@@ -20,6 +20,7 @@ const initialState = {
     '',
     '',
   ],
+  judges: [],
   image: null,
 };
 

--- a/src/competitions/create/newCompetition/reducer.js
+++ b/src/competitions/create/newCompetition/reducer.js
@@ -22,6 +22,10 @@ const initialState = {
   ],
   judges: [],
   image: null,
+  createCompetition: {
+    loading: false,
+    error: null,
+  },
 };
 
 const newCompetitionReducer = (state = initialState, action) => {
@@ -33,6 +37,34 @@ const newCompetitionReducer = (state = initialState, action) => {
       newState[field] = value;
       return newState;
 
+    // Actions related to creating new contest
+    case actionTypes.createCompetition.init:
+      return {
+        ...state,
+        createContest: {
+          loading: true,
+          error: null,
+        },
+      };
+
+    case actionTypes.createCompetition.done:
+      return {
+        ...state,
+        createContest: {
+          loading: false,
+          error: null,
+        },
+      };
+
+    case actionTypes.createCompetition.error:
+      return {
+        ...state,
+        createCompetition: {
+          loading: false,
+          error: action.reason,
+        },
+      };
+
     default:
       return state;
   }
@@ -42,3 +74,5 @@ export default newCompetitionReducer;
 
 // Selector
 export const getNewCompetitionField = (state, field) => getNewCompetitionState(state)[field];
+
+export const isCompetitionCreating = state => getNewCompetitionField(state, 'createCompetition').loading;

--- a/src/competitions/create/newCompetition/reducer.js
+++ b/src/competitions/create/newCompetition/reducer.js
@@ -40,7 +40,7 @@ const newCompetitionReducer = (state = initialState, action) => {
     case actionTypes.createCompetition.init:
       return {
         ...state,
-        createContest: {
+        createCompetition: {
           loading: true,
           error: null,
         },
@@ -49,7 +49,7 @@ const newCompetitionReducer = (state = initialState, action) => {
     case actionTypes.createCompetition.done:
       return {
         ...state,
-        createContest: {
+        createCompetition: {
           loading: false,
           error: null,
         },

--- a/src/competitions/create/newCompetition/styles.scss
+++ b/src/competitions/create/newCompetition/styles.scss
@@ -22,6 +22,8 @@
 }
 
 .dateRangeContainer {
+  padding: 8px;
+  margin-bottom: 16px;
   .inputsContainer {
     width: 160px;
     font-size: 16px;
@@ -48,6 +50,7 @@
 }
 
 .prizesEntry {
+  padding: 8px;
   .importantMark {
     color: red;
   }
@@ -72,6 +75,7 @@
 }
 
 .imageContainer {
+  padding: 8px;
   .button {
     width: max-content;
     padding: 8px 24px;

--- a/src/competitions/create/newCompetition/styles.scss
+++ b/src/competitions/create/newCompetition/styles.scss
@@ -1,0 +1,79 @@
+@import '../../../styles/variables';
+
+.bottomBar {
+  background: white;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: flex-end;
+  .button {
+    padding: 8px 24px;
+    margin-left: 16px;
+  }
+  padding: 24px;
+}
+
+.header {
+  font-size: 14px;
+  color: rgba(0, 0, 0, 0.54);
+  font-weight: bold;
+}
+
+.dateRangeContainer {
+  .inputsContainer {
+    width: 160px;
+    font-size: 16px;
+    color: rgba(0, 0, 0, 0.38);
+    > div {
+      align-items: end;
+    }
+    .label {
+      width: 96px;
+    }
+    input {
+      width: 100%;
+      border: none;
+      border-bottom: 1px solid rgba(99, 69, 69, 0.38);
+      text-align: center;
+      padding-bottom: 4px;
+      margin-right: 8px;
+      margin-bottom: 8px;
+    }
+    input:hover, input:focus {
+      border-bottom: 1px solid $primary-color;
+    }
+  }
+}
+
+.prizesEntry {
+  .importantMark {
+    color: red;
+  }
+  input {
+    margin-left: 8px;
+    border: none;
+    border-bottom: 1px solid rgba(99, 69, 69, 0.38);
+    padding-bottom: 4px;
+    margin-right: 8px;
+    margin-bottom: 8px;
+    font-size: 16px;
+    color: rgba(0, 0, 0, 0.54);
+  }
+  input:hover, input:focus {
+    border-bottom: 1px solid $primary-color;
+  }
+  .prizeLabel {
+    font-size: 16px;
+    color: rgba(0, 0, 0, 0.7);
+    width: 72px;
+  }
+}
+
+.imageContainer {
+  .button {
+    width: max-content;
+    padding: 8px 24px;
+  }
+}

--- a/src/competitions/create/newCompetition/styles.scss
+++ b/src/competitions/create/newCompetition/styles.scss
@@ -2,7 +2,7 @@
 
 .bottomBar {
   background: white;
-  position: absolute;
+  position: fixed;
   bottom: 0;
   left: 0;
   right: 0;

--- a/src/competitions/create/reducer.js
+++ b/src/competitions/create/reducer.js
@@ -2,16 +2,27 @@ import { combineReducers } from 'redux';
 
 import { getCompetitionsState } from '../reducer';
 import newCompetitionReducer from './newCompetition/reducer';
+import announcementPostReducer from './AnnouncementPost/reducer';
 
 const createReducer = combineReducers({
   newCompetition: newCompetitionReducer,
+  announce: announcementPostReducer,
 });
 
 export default createReducer;
 
 // Selectors
 
-// Gets us to the current reducer
+/**
+ * Returns the reducer's state
+ * @param {object} state Current state
+ */
 export const getCreateCompetitionState = state => getCompetitionsState(state).create;
 
+/**
+ * Returns the state related to new competition
+ * @param {object} state Current redux state
+ */
 export const getNewCompetitionState = state => getCreateCompetitionState(state).newCompetition;
+
+export const getAnnouncementPostState = state => getCreateCompetitionState(state).announce;

--- a/src/competitions/create/reducer.js
+++ b/src/competitions/create/reducer.js
@@ -3,10 +3,12 @@ import { combineReducers } from 'redux';
 import { getCompetitionsState } from '../reducer';
 import newCompetitionReducer from './newCompetition/reducer';
 import announcementPostReducer from './AnnouncementPost/reducer';
+import declareWinnersReducer from './DeclareWinners/reducer';
 
 const createReducer = combineReducers({
   newCompetition: newCompetitionReducer,
   announce: announcementPostReducer,
+  declareWinners: declareWinnersReducer,
 });
 
 export default createReducer;
@@ -26,3 +28,5 @@ export const getCreateCompetitionState = state => getCompetitionsState(state).cr
 export const getNewCompetitionState = state => getCreateCompetitionState(state).newCompetition;
 
 export const getAnnouncementPostState = state => getCreateCompetitionState(state).announce;
+
+export const getDeclareWinnersState = state => getCreateCompetitionState(state).declareWinners;

--- a/src/competitions/create/reducer.js
+++ b/src/competitions/create/reducer.js
@@ -1,0 +1,17 @@
+import { combineReducers } from 'redux';
+
+import { getCompetitionsState } from '../reducer';
+import newCompetitionReducer from './newCompetition/reducer';
+
+const createReducer = combineReducers({
+  newCompetition: newCompetitionReducer,
+});
+
+export default createReducer;
+
+// Selectors
+
+// Gets us to the current reducer
+export const getCreateCompetitionState = state => getCompetitionsState(state).create;
+
+export const getNewCompetitionState = state => getCreateCompetitionState(state).newCompetition;

--- a/src/competitions/create/routes.js
+++ b/src/competitions/create/routes.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+
+export default () => (
+  <Switch>
+    <Route exact path="/competitions/~create/description" render={() => 'Description'} />
+    <Route exact path="/competitions/~create/details" render={() => 'Details'} />
+    <Route exact path="/competitions/~create/post/:competitionId/announce" render={() => 'Announce'} />,
+  </Switch>
+);

--- a/src/competitions/create/routes.js
+++ b/src/competitions/create/routes.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 
+import Description from './newCompetition/Description';
+import Details from './newCompetition/Details';
+
 export default () => (
   <Switch>
-    <Route exact path="/competitions/~create/description" render={() => 'Description'} />
-    <Route exact path="/competitions/~create/details" render={() => 'Details'} />
+    <Route exact path="/competitions/~create" component={Description} />
+    <Route exact path="/competitions/~create/details" component={Details} />
     <Route exact path="/competitions/~create/post/:competitionId/announce" render={() => 'Announce'} />,
   </Switch>
 );

--- a/src/competitions/create/routes.js
+++ b/src/competitions/create/routes.js
@@ -4,11 +4,21 @@ import { Switch, Route } from 'react-router-dom';
 import Description from './newCompetition/Description';
 import Details from './newCompetition/Details';
 import AnnouncementPost from './AnnouncementPost';
+import DeclareWinners from './DeclareWinners';
 
 export default () => (
   <Switch>
     <Route exact path="/competitions/~create" component={Description} />
     <Route exact path="/competitions/~create/details" component={Details} />
+    <Route
+      exact
+      path="/competitions/~create/declare-winners/:competitionId"
+      render={({ match }) => {
+        const { params } = match;
+        const { competitionId } = params;
+        return <DeclareWinners competitionId={competitionId} />;
+      }}
+    />
     <Route
       exact
       path="/competitions/~create/post/:competitionId/:mode"

--- a/src/competitions/create/routes.js
+++ b/src/competitions/create/routes.js
@@ -3,11 +3,20 @@ import { Switch, Route } from 'react-router-dom';
 
 import Description from './newCompetition/Description';
 import Details from './newCompetition/Details';
+import AnnouncementPost from './AnnouncementPost';
 
 export default () => (
   <Switch>
     <Route exact path="/competitions/~create" component={Description} />
     <Route exact path="/competitions/~create/details" component={Details} />
-    <Route exact path="/competitions/~create/post/:competitionId/announce" render={() => 'Announce'} />,
+    <Route
+      exact
+      path="/competitions/~create/post/:competitionId/:mode"
+      render={({ match }) => {
+        const { params } = match;
+        const { competitionId, mode } = params;
+        return <AnnouncementPost competitionId={competitionId} mode={mode} />;
+      }}
+    />,
   </Switch>
 );

--- a/src/competitions/reducer.js
+++ b/src/competitions/reducer.js
@@ -7,6 +7,7 @@ import leaderboardReducer from './Leaderboard/reducer';
 import createReducer from './create/reducer';
 import { actionTypes } from './actions';
 import { getPostByPermlink } from '../post/reducer';
+import { getAuthUsername } from '../reducers/authUserReducer';
 
 const initialState = {
   loading: false,
@@ -201,3 +202,24 @@ export const getLastCompetitionId = (state) => {
  * @param {object} state Current state
  */
 export const hasMore = state => getCompetitionsState(state).competitions.hasMore;
+
+/**
+ * Checks if a competition with the given competition ID
+ * is present
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
+export const isCompetitionAvailable = (state, competitionId) =>
+  !!getCompetitionById(state, competitionId);
+
+export const isAnnounceAllowed = (state, competitionId) => {
+  const currentUser = getAuthUsername(state);
+  if (!currentUser) {
+    return false;
+  }
+  const competition = getCompetitionById(state, competitionId);
+  if (!competition) {
+    return false;
+  }
+  return currentUser === competition.user.username;
+};

--- a/src/competitions/reducer.js
+++ b/src/competitions/reducer.js
@@ -11,7 +11,9 @@ import { getPostByPermlink } from '../post/reducer';
 const initialState = {
   loading: false,
   error: null,
-  competitions: [],
+  // 'hasMore' Says if there may be more competitions to fetch from backend
+  hasMore: true,
+  competitionsById: {},
   competitionPosts: {},
 };
 
@@ -23,10 +25,28 @@ const competitionsReducer = (state = initialState, action) => {
       return { ...state, error: null, loading: true };
 
     case actionTypes.getAll.done:
-      return { ...state, loading: false, competitions: action.results };
+      return {
+        ...state,
+        loading: false,
+        competitionsById: action.results.reduce(
+          (acc, curr) => {
+            acc[curr.id] = curr;
+            return acc;
+          },
+          state.competitionsById,
+        ),
+        hasMore: action.results.length > 0,
+      };
 
     case actionTypes.getAll.error:
       return { ...state, loading: false, error: action.reason };
+
+    //  Single competition
+    case actionTypes.getCompetition.done:
+      // Clone only competitions data
+      newState = cloneDeep(state.competitionsById);
+      newState[action.competitionId] = action.result;
+      return { ...state, competitionsById: newState };
 
     // Competition posts
     case actionTypes.getPosts.init:
@@ -80,11 +100,37 @@ export default combineReducers({
 });
 
 // selectors
+/**
+ * Returns state for this reducer given the global redux state
+ * @param {object} state Current redux state
+ */
 export const getCompetitionsState = state => state.competitions;
-export const getAllCompetitions = state => getCompetitionsState(state).competitions.competitions;
 
+/**
+ * Returns all competitions in descending order of
+ * creating time
+ * @param {object} state Current redux state
+ */
+export const getAllCompetitions = (state) => {
+  const { competitionsById } = getCompetitionsState(state).competitions;
+  return Object.values(competitionsById)
+    // Sort based on time of creation
+    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+};
+
+/**
+ * Returns true if we are currently fetching competitions
+ * @param {object} state Current redux state
+ */
 export const isCompetitionsFetching = state => getCompetitionsState(state).competitions.loading;
 
+/**
+ * Returns permlinks for entries to a contest, such
+ * that winning entries appear in the beginning of
+ * the array
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
 export const getCompetitionPostPermlinks = (state, competitionId) => {
   const winners = get(
     getCompetitionsState(state),
@@ -96,26 +142,62 @@ export const getCompetitionPostPermlinks = (state, competitionId) => {
     `competitions.competitionPosts.${competitionId}.posts`,
     [],
   );
-
   return uniq([...winners, ...posts]);
 };
 
+/**
+ * Returns all submissions to a contest given the
+ * competition ID
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
 export const getCompetitionPosts = (state, competitionId) => {
   const postPermlinks = getCompetitionPostPermlinks(getCompetitionsState(state), competitionId);
 
   // Extract all posts from allPosts reducer
   const posts = postPermlinks
     .map(permlink => getPostByPermlink(getCompetitionsState(state), permlink))
-    .filter(post => post); // Remove empty
+    .filter(post => post) // Remove empty
+    .sort((a, b) => new Date(b) - new Date(a)); // Sort based on date
 
   return posts;
 };
 
+/**
+ * Fetches a competition given its ID
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
 export const getCompetitionById = (state, competitionId) => getCompetitionsState(state)
-  .competitions.competitions.find(competition => competition.id === competitionId);
+  .competitions.competitionsById[competitionId];
 
+/**
+ * Finds out if posts for a competition is loading, given
+ * its ID
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
 export const isPostsLoading = (state, competitionId) => get(
   getCompetitionsState(state),
   `competitions.competitionPosts.${competitionId}.loading`,
   false,
 );
+
+/**
+ * Extracts the last competition ID or null if there
+ * are no competitions present in store
+ * @param {object} state Current redux state
+ */
+export const getLastCompetitionId = (state) => {
+  const competitions = getAllCompetitions(state);
+  if (competitions.length === 0) {
+    return undefined;
+  }
+  return competitions[competitions.length - 1].id;
+};
+
+/**
+ * Fetched the hasMore variable
+ * @param {object} state Current state
+ */
+export const hasMore = state => getCompetitionsState(state).competitions.hasMore;

--- a/src/competitions/reducer.js
+++ b/src/competitions/reducer.js
@@ -236,6 +236,11 @@ export const hasCompetitionEnded = (state, competitionId) => {
   return endDate < now;
 };
 
+/**
+ * Returns true if winners for a competition are announced
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
 export const isWinnersDeclared = (state, competitionId) => {
   const competition = getCompetitionById(state, competitionId);
   return competition.winners_announced;

--- a/src/competitions/reducer.js
+++ b/src/competitions/reducer.js
@@ -288,11 +288,7 @@ export const isAnnouncePostAllowed = (state, competitionId) => {
   if (!isAnnounceAllowed(state, competitionId)) {
     return false;
   }
-
   const competition = getCompetitionById(state, competitionId);
-
-  console.log(competition.announce_permlink);
-
   return !competition.announce_permlink;
 };
 

--- a/src/competitions/reducer.js
+++ b/src/competitions/reducer.js
@@ -198,7 +198,7 @@ export const getLastCompetitionId = (state) => {
 };
 
 /**
- * Fetched the hasMore variable
+ * Fetches the hasMore variable
  * @param {object} state Current state
  */
 export const hasMore = state => getCompetitionsState(state).competitions.hasMore;

--- a/src/competitions/reducer.js
+++ b/src/competitions/reducer.js
@@ -4,6 +4,7 @@ import get from 'lodash/get';
 import uniq from 'lodash/uniq';
 
 import leaderboardReducer from './Leaderboard/reducer';
+import createReducer from './create/reducer';
 import { actionTypes } from './actions';
 import { getPostByPermlink } from '../post/reducer';
 
@@ -75,6 +76,7 @@ const competitionsReducer = (state = initialState, action) => {
 export default combineReducers({
   competitions: competitionsReducer,
   leaderboard: leaderboardReducer,
+  create: createReducer,
 });
 
 // selectors

--- a/src/competitions/reducer.js
+++ b/src/competitions/reducer.js
@@ -223,3 +223,46 @@ export const isAnnounceAllowed = (state, competitionId) => {
   }
   return currentUser === competition.user.username;
 };
+
+/**
+ * Returns true if a contest has ended
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
+export const hasCompetitionEnded = (state, competitionId) => {
+  const competition = getCompetitionById(state, competitionId);
+  const endDate = new Date(competition.ends_at);
+  const now = new Date();
+  return endDate < now;
+};
+
+export const isWinnersDeclared = (state, competitionId) => {
+  const competition = getCompetitionById(state, competitionId);
+  return competition.winners_announced;
+};
+
+/**
+ * Returns true if winners for a competitino can be declared
+ * i.e., all of the following conditions should meet
+ * - Competition should exist
+ * - Current user should be allowed to declare winners
+ * - Competition should have ended
+ * - Winners should not be declared aready
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
+export const isWinnerDeclareAllowed = (state, competitionId) => {
+  if (!isCompetitionAvailable(state, competitionId)) {
+    return false;
+  }
+
+  if (!isAnnounceAllowed(state, competitionId)) {
+    return false;
+  }
+
+  if (!hasCompetitionEnded(state, competitionId)) {
+    return false;
+  }
+
+  return !isWinnersDeclared(state, competitionId);
+};

--- a/src/competitions/reducer.js
+++ b/src/competitions/reducer.js
@@ -3,6 +3,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import uniq from 'lodash/uniq';
 
+import leaderboardReducer from './Leaderboard/reducer';
 import { actionTypes } from './actions';
 import { getPostByPermlink } from '../post/reducer';
 
@@ -73,6 +74,7 @@ const competitionsReducer = (state = initialState, action) => {
 
 export default combineReducers({
   competitions: competitionsReducer,
+  leaderboard: leaderboardReducer,
 });
 
 // selectors

--- a/src/competitions/reducer.js
+++ b/src/competitions/reducer.js
@@ -1,3 +1,4 @@
+import { combineReducers } from 'redux';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import uniq from 'lodash/uniq';
@@ -12,7 +13,7 @@ const initialState = {
   competitionPosts: {},
 };
 
-export default (state = initialState, action) => {
+const competitionsReducer = (state = initialState, action) => {
   let newState;
   switch (action.type) {
     // All competitions
@@ -70,19 +71,24 @@ export default (state = initialState, action) => {
   }
 };
 
-// selectors
-export const getAllCompetitions = state => state.competitions.competitions;
+export default combineReducers({
+  competitions: competitionsReducer,
+});
 
-export const isCompetitionsFetching = state => state.competitions.loading;
+// selectors
+export const getCompetitionsState = state => state.competitions;
+export const getAllCompetitions = state => getCompetitionsState(state).competitions.competitions;
+
+export const isCompetitionsFetching = state => getCompetitionsState(state).competitions.loading;
 
 export const getCompetitionPostPermlinks = (state, competitionId) => {
   const winners = get(
-    state,
+    getCompetitionsState(state),
     `competitions.competitionPosts.${competitionId}.winners`,
     [],
   );
   const posts = get(
-    state,
+    getCompetitionsState(state),
     `competitions.competitionPosts.${competitionId}.posts`,
     [],
   );
@@ -91,21 +97,21 @@ export const getCompetitionPostPermlinks = (state, competitionId) => {
 };
 
 export const getCompetitionPosts = (state, competitionId) => {
-  const postPermlinks = getCompetitionPostPermlinks(state, competitionId);
+  const postPermlinks = getCompetitionPostPermlinks(getCompetitionsState(state), competitionId);
 
   // Extract all posts from allPosts reducer
   const posts = postPermlinks
-    .map(permlink => getPostByPermlink(state, permlink))
+    .map(permlink => getPostByPermlink(getCompetitionsState(state), permlink))
     .filter(post => post); // Remove empty
 
   return posts;
 };
 
-export const getCompetitionById = (state, competitionId) => state
+export const getCompetitionById = (state, competitionId) => getCompetitionsState(state)
   .competitions.competitions.find(competition => competition.id === competitionId);
 
 export const isPostsLoading = (state, competitionId) => get(
-  state,
+  getCompetitionsState(state),
   `competitions.competitionPosts.${competitionId}.loading`,
   false,
 );

--- a/src/competitions/reducer.js
+++ b/src/competitions/reducer.js
@@ -212,6 +212,12 @@ export const hasMore = state => getCompetitionsState(state).competitions.hasMore
 export const isCompetitionAvailable = (state, competitionId) =>
   !!getCompetitionById(state, competitionId);
 
+/**
+ * Returns true if the current logged in user is creator
+ * of the competition
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
 export const isAnnounceAllowed = (state, competitionId) => {
   const currentUser = getAuthUsername(state);
   if (!currentUser) {
@@ -270,4 +276,37 @@ export const isWinnerDeclareAllowed = (state, competitionId) => {
   }
 
   return !isWinnersDeclared(state, competitionId);
+};
+
+/**
+ * Returns true if writing announcement post for the
+ * competition is possible
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
+export const isAnnouncePostAllowed = (state, competitionId) => {
+  if (!isAnnounceAllowed(state, competitionId)) {
+    return false;
+  }
+
+  const competition = getCompetitionById(state, competitionId);
+
+  console.log(competition.announce_permlink);
+
+  return !competition.announce_permlink;
+};
+
+/**
+ * Returns true if writing winner declaration post
+ * for the competition is possible
+ * @param {object} state Current redux state
+ * @param {string} competitionId Competition ID
+ */
+export const isDeclareWinnerPostAllowed = (state, competitionId) => {
+  if (!isAnnounceAllowed(state, competitionId)) {
+    return false;
+  }
+  const competition = getCompetitionById(state, competitionId);
+
+  return competition.winners_announced && !competition.declare_winners_permlink;
 };

--- a/src/components/BodyModal.js
+++ b/src/components/BodyModal.js
@@ -13,6 +13,16 @@ const enableParentScroll = () => {
 
 const noOp = () => { };
 
+const defaultStyle = {
+  overlay: {
+    backgroundColor: '#fafafafa',
+    zIndex: 1,
+  },
+  content: {
+    boxShadow: '0 4px 12px rgba(0,0,0,.15)',
+  },
+};
+
 const BodyModal = props => (
   <Modal
     {...props}
@@ -38,6 +48,10 @@ const BodyModal = props => (
       enableParentScroll();
     }}
     parentSelector={parentSelector}
+    style={{
+      ...defaultStyle,
+      ...props.style,
+    }}
   />
 );
 
@@ -50,15 +64,7 @@ BodyModal.propTypes = {
 BodyModal.defaultProps = {
   onAfterOpen: noOp,
   onAfterClose: noOp,
-  style: { // Default style
-    overlay: {
-      backgroundColor: '#fafafafa',
-      zIndex: 1,
-    },
-    content: {
-      boxShadow: '0 4px 12px rgba(0,0,0,.15)',
-    },
-  },
+  style: {},
 };
 
 export default BodyModal;

--- a/src/components/ConfirmationModal/index.js
+++ b/src/components/ConfirmationModal/index.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import PrimaryButton from '../buttons/PrimaryButton';
+import DefaultButton from '../buttons/DefaultButton';
+import BodyModal from '../BodyModal';
+import styles from './styles.scss';
+
+const noop = () => { };
+
+const ConfirmationModal = ({
+  onConfirm, onCancel, children, confirmContent,
+  cancelContent, confirmActive, cancelActive,
+}) => (
+  <BodyModal
+    isOpen
+    onClose={onCancel}
+    className="uk-position-center"
+  >
+    <div className={styles.modalContainer}>
+      <div style={{ maxHeight: 200 }}>
+        {children}
+      </div>
+
+      {/* Cancel/Confirm buttons */}
+      <div className="uk-flex uk-flex-right">
+        <DefaultButton
+          className="uk-margin-right"
+          onClick={onCancel}
+          disabled={!cancelActive}
+        >
+          {cancelContent}
+        </DefaultButton>
+        <PrimaryButton
+          onClick={onConfirm}
+          disabled={!confirmActive}
+        >
+          {confirmContent}
+        </PrimaryButton>
+      </div>
+    </div>
+  </BodyModal>
+);
+
+const contentPropType = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.node,
+  PropTypes.arrayOf(PropTypes.node),
+]);
+
+ConfirmationModal.propTypes = {
+  onConfirm: PropTypes.func,
+  onCancel: PropTypes.func,
+  children: contentPropType,
+  confirmContent: contentPropType,
+  cancelContent: contentPropType,
+  confirmActive: PropTypes.bool,
+  cancelActive: PropTypes.bool,
+};
+
+ConfirmationModal.defaultProps = {
+  onConfirm: noop,
+  onCancel: noop,
+  children: 'Confirm?',
+  confirmContent: 'Confirm',
+  cancelContent: 'Cancel',
+  confirmActive: true,
+  cancelActive: true,
+};
+
+export default ConfirmationModal;

--- a/src/components/ConfirmationModal/styles.scss
+++ b/src/components/ConfirmationModal/styles.scss
@@ -1,0 +1,5 @@
+.modalContainer {
+  background: white;
+  padding: 24px;
+  max-width: 800px;
+}

--- a/src/components/UserAvatar/index.js
+++ b/src/components/UserAvatar/index.js
@@ -10,7 +10,7 @@ const allowedSizes = [
 
 const UserAvatar = ({
   username, size, className, tooltip,
-  noLink, ...props
+  noLink, style, ...props
 }) => {
   const realSize = allowedSizes.filter(i => i === size)[0] || 'medium';
   const tooltipProp = tooltip ? { 'uk-tooltip': `@${username}` } : {};
@@ -19,6 +19,7 @@ const UserAvatar = ({
     ...props,
     style: {
       backgroundImage: `url(https://steemitimages.com/u/${username}/avatar/${realSize})`,
+      ...style,
     },
     ...tooltipProp,
   };
@@ -43,6 +44,7 @@ UserAvatar.propTypes = {
   className: PropTypes.string,
   tooltip: PropTypes.bool,
   noLink: PropTypes.bool,
+  style: PropTypes.shape(),
 };
 
 UserAvatar.defaultProps = {
@@ -51,6 +53,7 @@ UserAvatar.defaultProps = {
   className: '',
   tooltip: false,
   noLink: false,
+  style: {},
 };
 
 export default UserAvatar;

--- a/src/components/ViewContainer/index.js
+++ b/src/components/ViewContainer/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import styles from './styles.scss';
+
+const ViewContainer = props => <div className={styles.viewContainer} {...props} />;
+
+export default ViewContainer;

--- a/src/components/ViewContainer/styles.scss
+++ b/src/components/ViewContainer/styles.scss
@@ -1,0 +1,12 @@
+.viewContainer {
+  max-width: 800px;
+  width: 100vw;
+  margin: 36px auto;
+  background: white;
+
+  > div {
+    @media screen and (min-width: 700px) {
+      padding: 24px;
+    }
+  }
+}

--- a/src/components/addContentButton/index.js
+++ b/src/components/addContentButton/index.js
@@ -36,7 +36,15 @@ class AddContentButton extends React.Component {
               <div className={`${styles.iconContainer}`}>
                 <Icon name="photo" type="solid" />
               </div>
-              <span className="uk-margin-small-left">Post</span>
+              <span className="uk-margin-small-left">Short Post</span>
+            </Link>
+          </div>
+          <div className={['uk-margin-bottom', styles.contentType].join(' ')}>
+            <Link to="/competitions/~create" className="uk-flex">
+              <div className={`${styles.iconContainer}`}>
+                <Icon name="competition_white" type="solid" />
+              </div>
+              <span className="uk-margin-small-left">Create a Contest</span>
             </Link>
           </div>
         </div>}

--- a/src/components/addContentButton/styles.scss
+++ b/src/components/addContentButton/styles.scss
@@ -59,11 +59,20 @@
   line-height: 48px;
   background: #FFFFFF;
   box-shadow: 0 0 4px 0 rgba(0,0,0,0.12), 0 4px 4px 0 rgba(0,0,0,0.12);
+  text-align: center;
+  a {
+    white-space: nowrap;
+    text-align: center;
+    width: 100%;
+    span {
+      width: 100%;
+    }
+  }
 }
 
 .iconContainer {
-  width: 48px;
-  height: 48px;
+  min-width: 48px;
+  min-height: 48px;
   background-color: $primary-color;
   border-radius: 50%;
   line-height: 48px;

--- a/src/components/input/Input/index.js
+++ b/src/components/input/Input/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import styles from './styles.scss';
+
+const Input = ({ className, ...props }) => (
+  <input
+    className={`${styles.inputNode} ${className} uk-input`}
+    {...props}
+  />
+);
+
+Input.propTypes = {
+  className: PropTypes.string,
+};
+
+Input.defaultProps = {
+  className: '',
+};
+
+export default Input;

--- a/src/components/input/Input/styles.scss
+++ b/src/components/input/Input/styles.scss
@@ -1,0 +1,7 @@
+@import '../../../styles/variables';
+
+.inputNode {
+  border: none;
+  padding-left: 16px;
+  border-left: 4px solid $background-color;
+}

--- a/src/components/input/TextArea/index.js
+++ b/src/components/input/TextArea/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TextAreaAutosize from 'react-autosize-textarea';
+
+import styles from './styles.scss';
+
+const Input = ({ className, ...props }) => (
+  <TextAreaAutosize
+    className={`${styles.textAreaNode} ${className} uk-textarea`}
+    {...props}
+  />
+);
+
+Input.propTypes = {
+  className: PropTypes.string,
+};
+
+Input.defaultProps = {
+  className: '',
+};
+
+export default Input;

--- a/src/components/input/TextArea/styles.scss
+++ b/src/components/input/TextArea/styles.scss
@@ -1,0 +1,8 @@
+@import '../../../styles/variables';
+
+.textAreaNode {
+  resize: none;
+  border: none;
+  padding-left: 16px;
+  border-left: 4px solid $background-color;
+}

--- a/src/components/root/index.js
+++ b/src/components/root/index.js
@@ -185,7 +185,15 @@ const Root = ({
       <Route exact path="/profile/edit" component={authRequiredComponent(EditProfile)} />
 
       <Route exact path="/competitions" component={CompetitionListing} />
-      <Route path="/competitions/~create" component={CreateCompetitionsRoute} />
+      <Route
+        path="/competitions/~create"
+        render={(props) => {
+          if (isLoggedIn) {
+            return <CreateCompetitionsRoute {...props} />;
+          }
+          return <Redirect to="/competitions" />;
+        }}
+      />
       <Route exact path="/competitions/:competitionId" component={CompetitionSingle} />
 
       <Route exact path="/community/:tag" component={MicroCommunitySingle} />

--- a/src/components/root/index.js
+++ b/src/components/root/index.js
@@ -90,10 +90,11 @@ const bottomBarWhitelistURLs = [
   '^/@.*$',
   '^/competitions.*$',
 ];
-
 const bottomBarBlacklistURLs = [
   '^/@.*?/.*$',
+  '^/competitions/~create.*$',
 ];
+
 const showBottomBar = (location, authUsername) => {
   // Special case for not showing bottom bar on other's profiles
   if (

--- a/src/components/root/index.js
+++ b/src/components/root/index.js
@@ -80,6 +80,10 @@ const MicroCommunitySingle = Loadable({
   loader: () => import('../../microCommunities/MicroCommunitySingle'),
   loading: Loading,
 });
+const CreateCompetitionsRoute = Loadable({
+  loader: () => import('../../competitions/create/routes'),
+  loading: Loading,
+});
 
 const bottomBarWhitelistURLs = [
   '^/feed/.*$',
@@ -180,6 +184,7 @@ const Root = ({
       <Route exact path="/profile/edit" component={authRequiredComponent(EditProfile)} />
 
       <Route exact path="/competitions" component={CompetitionListing} />
+      <Route path="/competitions/~create" component={CreateCompetitionsRoute} />
       <Route exact path="/competitions/:competitionId" component={CompetitionSingle} />
 
       <Route exact path="/community/:tag" component={MicroCommunitySingle} />

--- a/src/icons/outline/calender.svg
+++ b/src/icons/outline/calender.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53 (72520) - https://sketchapp.com -->
+    <title>Icons/outline/calender@3x</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Icons/outline/calender" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Interface-Essential-/-Date/Calendar-/-calendar" stroke="#000000" stroke-width="1.5">
+            <g id="Group">
+                <g id="calendar">
+                    <rect id="Rectangle-path" x="0.564" y="2.8125" width="16.875" height="14.625" rx="1.5"></rect>
+                    <path d="M0.564,7.3125 L17.439,7.3125" id="Shape"></path>
+                    <path d="M5.064,4.5 L5.064,0.5625" id="Shape"></path>
+                    <path d="M12.939,4.5 L12.939,0.5625" id="Shape"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/post/PostCard/index.js
+++ b/src/post/PostCard/index.js
@@ -66,7 +66,10 @@ const Post = (props) => {
   /* Render */
   return (
     <LazyLoad height={800} once>
-      <div className={`uk-margin-bottom ${props.border ? styles.postContainerBorder : ''} ${indexStyles.white} ${styles.postContainer}`}>
+      <div
+        className={`uk-margin-bottom ${props.border ? styles.postContainerBorder : ''} ${indexStyles.white} ${styles.postContainer} ${props.className}`}
+        style={props.style}
+      >
         {
           props.showPrize
           && props.post.rank
@@ -104,6 +107,8 @@ Post.propTypes = {
   maintainAspectRatio: PropTypes.bool,
   showPrize: PropTypes.bool,
   showPercentByUser: PropTypes.string,
+  style: PropTypes.shape(),
+  className: PropTypes.string,
 };
 
 Post.defaultProps = {
@@ -112,6 +117,8 @@ Post.defaultProps = {
   maintainAspectRatio: false,
   showPrize: false,
   showPercentByUser: null,
+  style: {},
+  className: '',
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/post/create/CreateArticle/ArticleNext/TagsSelector/index.js
+++ b/src/post/create/CreateArticle/ArticleNext/TagsSelector/index.js
@@ -10,6 +10,10 @@ export default class TagsSelector extends React.Component {
     addTag: PropTypes.func,
     removeTag: PropTypes.func,
     className: PropTypes.string,
+    PrefixComponent: PropTypes.func,
+    prefixPropsSelector: PropTypes.func,
+    headerText: PropTypes.string,
+    disabled: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -17,6 +21,10 @@ export default class TagsSelector extends React.Component {
     addTag: () => { },
     removeTag: () => { },
     className: '',
+    PrefixComponent: () => '#',
+    prefixPropsSelector: () => ({}),
+    headerText: 'Tags',
+    disabled: false,
   }
 
   constructor(props) {
@@ -37,7 +45,7 @@ export default class TagsSelector extends React.Component {
       const { tagInputText } = this.state;
       const { addTag } = this.props;
 
-      if (tagInputText.length > 0) {
+      if (tagInputText.length > 0 && !this.props.disabled) {
         addTag(tagInputText);
       }
 
@@ -48,12 +56,15 @@ export default class TagsSelector extends React.Component {
   removeTag = tag => () => this.props.removeTag(tag);
 
   render() {
-    const { tags } = this.props;
+    const {
+      tags, PrefixComponent, prefixPropsSelector, headerText,
+      disabled,
+    } = this.props;
     const { tagInputText } = this.state;
     return (
       <div className={`${this.props.className} uk-container`}>
         <div className="uk-margin-small-bottom">
-          <span>Tags</span>
+          <span>{headerText}</span>
         </div>
 
         <div className="uk-grid">
@@ -68,7 +79,7 @@ export default class TagsSelector extends React.Component {
                 tabIndex={-1}
               >
                 <span className={styles.tagContainer}>
-                  #{tag}
+                  <PrefixComponent {...prefixPropsSelector(tag)} />{tag}
                   <img
                     className={styles.cancelButton}
                     src={getIcon('cancel', 'outline')}
@@ -79,12 +90,16 @@ export default class TagsSelector extends React.Component {
             ))
           }
           <div>
-            <input
-              className={styles.inputContainer}
-              value={tagInputText}
-              onChange={this.handleTagInputChange}
-              onKeyUp={this.handleTagInputKeyUp}
-            />
+            {
+              !disabled && (
+                <input
+                  className={styles.inputContainer}
+                  value={tagInputText}
+                  onChange={this.handleTagInputChange}
+                  onKeyUp={this.handleTagInputKeyUp}
+                />
+              )
+            }
           </div>
         </div>
       </div>

--- a/src/post/create/CreateArticle/ArticleNext/TagsSelector/index.js
+++ b/src/post/create/CreateArticle/ArticleNext/TagsSelector/index.js
@@ -14,6 +14,7 @@ export default class TagsSelector extends React.Component {
     prefixPropsSelector: PropTypes.func,
     headerText: PropTypes.string,
     disabled: PropTypes.bool,
+    style: PropTypes.shape(),
   }
 
   static defaultProps = {
@@ -25,6 +26,7 @@ export default class TagsSelector extends React.Component {
     prefixPropsSelector: () => ({}),
     headerText: 'Tags',
     disabled: false,
+    style: {},
   }
 
   constructor(props) {
@@ -58,11 +60,11 @@ export default class TagsSelector extends React.Component {
   render() {
     const {
       tags, PrefixComponent, prefixPropsSelector, headerText,
-      disabled,
+      disabled, style,
     } = this.props;
     const { tagInputText } = this.state;
     return (
-      <div className={`${this.props.className} uk-container`}>
+      <div style={style} className={`${this.props.className} uk-container`}>
         <div className="uk-margin-small-bottom">
           <span>{headerText}</span>
         </div>

--- a/src/post/create/CreateArticle/ArticleNext/TagsSelector/styles.scss
+++ b/src/post/create/CreateArticle/ArticleNext/TagsSelector/styles.scss
@@ -7,6 +7,8 @@
   background-color: $background-color;
   border-radius: 21px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .cancelButton {

--- a/src/post/create/CreateArticle/ArticleNext/index.js
+++ b/src/post/create/CreateArticle/ArticleNext/index.js
@@ -9,8 +9,6 @@ import TagsSelector from './TagsSelector';
 import DefaultButton from '../../../../components/buttons/DefaultButton';
 import PrimaryButton from '../../../../components/buttons/PrimaryButton';
 
-
-import { getAllCommunities } from '../../../../reducers/communitiesReducer';
 import { getSelectedCommunities, getActiveTags, isArticlePublishable } from '../reducer';
 import { changeCommunity, addTag, removeTag, createArticle } from '../actions';
 import indexStyles from '../../../../styles/globals.scss';
@@ -18,7 +16,6 @@ import styles from './styles.scss';
 
 class ArticleNext extends React.Component {
   static propTypes = {
-    communities: PropTypes.arrayOf(PropTypes.shape()).isRequired,
     selectedCommunities: PropTypes.arrayOf(PropTypes.shape()).isRequired,
     changeCommunity: PropTypes.func.isRequired,
     tags: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -34,7 +31,6 @@ class ArticleNext extends React.Component {
     return (
       <div className={`uk-container uk-padding ${indexStyles.white}`}>
         <CommunitySelector
-          communities={this.props.communities}
           selectedCommunities={this.props.selectedCommunities}
           onClick={c => this.props.changeCommunity(c.id)}
           className={styles.communitySelectorContainer}
@@ -66,7 +62,6 @@ class ArticleNext extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  communities: getAllCommunities(state),
   selectedCommunities: getSelectedCommunities(state),
   tags: getActiveTags(state),
   isPublishEnabled: isArticlePublishable(state),

--- a/src/post/create/CreatePost/CommunitySelector/index.js
+++ b/src/post/create/CreatePost/CommunitySelector/index.js
@@ -6,10 +6,11 @@ import styles from './styles.scss';
 import { getAllCommunities } from '../../../../reducers/communitiesReducer';
 
 const CommunitySelector = ({
-  communities, selectedCommunities, onClick, className, ...props
+  communities, selectedCommunities, onClick, className,
+  backgroundColor, interestBackground, ...props
 }) => (
-  <div {...props} className={`${className} ${styles.container}`}>
-    <div style={{ color: 'rgba(0, 0, 0, 0.38)', marginBottom: 8 }}>
+  <div {...props} style={{ background: backgroundColor }} className={`${className} ${styles.container}`}>
+    <div style={{ color: backgroundColor, marginBottom: 8 }}>
       <span className={`${styles.communityHeader}`}>
         Select Communities (Max 3)
       </span>
@@ -21,6 +22,7 @@ const CommunitySelector = ({
             key={community.id}
             style={{
               padding: '4px 10px',
+              background: interestBackground,
             }}
             className={`${styles.communityLabel} ${selectedCommunities.includes(community.id) ? styles.communitySelected : styles.communityNormal} uk-margin-small-bottom`}
             onClick={() => onClick(community)}
@@ -42,6 +44,8 @@ CommunitySelector.propTypes = {
   selectedCommunities: PropTypes.arrayOf(PropTypes.shape()),
   onClick: PropTypes.func,
   className: PropTypes.string,
+  backgroundColor: PropTypes.string,
+  interestBackground: PropTypes.string,
 };
 
 CommunitySelector.defaultProps = {
@@ -49,6 +53,8 @@ CommunitySelector.defaultProps = {
   selectedCommunities: [],
   onClick: () => {},
   className: '',
+  backgroundColor: 'rgba(0, 0, 0, 0.38)',
+  interestBackground: 'white',
 };
 
 const mapStateToProps = state => ({

--- a/src/post/create/CreatePost/CommunitySelector/index.js
+++ b/src/post/create/CreatePost/CommunitySelector/index.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import styles from './styles.scss';
+import { getAllCommunities } from '../../../../reducers/communitiesReducer';
 
 const CommunitySelector = ({
   communities, selectedCommunities, onClick, className, ...props
@@ -49,4 +51,8 @@ CommunitySelector.defaultProps = {
   className: '',
 };
 
-export default CommunitySelector;
+const mapStateToProps = state => ({
+  communities: getAllCommunities(state),
+});
+
+export default connect(mapStateToProps)(CommunitySelector);

--- a/src/post/create/CreatePost/CommunitySelector/styles.scss
+++ b/src/post/create/CreatePost/CommunitySelector/styles.scss
@@ -31,7 +31,7 @@
 }
 
 .communitySelected {
-  background-color: $primary-color;
+  background-color: $primary-color !important;
   color: white;
   transition: all ease-out 0.3s;
 }

--- a/src/post/create/CreatePost/index.js
+++ b/src/post/create/CreatePost/index.js
@@ -63,7 +63,7 @@ class CreatePost extends React.Component {
       return <Redirect to={`/@${this.props.fullPermlink}`} />;
     }
 
-    const { communities, activeCommunity, hashtags } = this.props;
+    const { activeCommunity, hashtags } = this.props;
 
     return (
       <div className={['uk-flex', 'uk-flex-center'].join(' ')}>
@@ -88,7 +88,6 @@ class CreatePost extends React.Component {
 
           {/* Community section */}
           <CommunitySelector
-            communities={communities}
             selectedCommunities={activeCommunity}
             onClick={c => this.props.changeCommunity(c.id)}
             style={{ marginBottom: 24 }}
@@ -104,10 +103,6 @@ CreatePost.propTypes = {
   resetPostCreate: PropTypes.func,
   postCreated: PropTypes.bool,
   fullPermlink: PropTypes.string,
-  communities: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number,
-    tag: PropTypes.string,
-  })),
   setHashtags: PropTypes.func,
   clearError: PropTypes.func,
   username: PropTypes.string.isRequired,
@@ -127,7 +122,6 @@ CreatePost.defaultProps = {
   resetPostCreate: () => {},
   postCreated: false,
   fullPermlink: '',
-  communities: [],
   setHashtags: () => {},
   clearError: () => {},
   activeCommunity: [],
@@ -141,7 +135,6 @@ CreatePost.defaultProps = {
 const mapStateToProps = state => ({
   userFullName: state.authUser.name,
   username: state.authUser.username,
-  communities: state.communities.communities,
   activeCommunity: state.createPost.community,
   media: state.createPost.media,
   hashtags: state.createPost.hashtags,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -17,7 +17,6 @@ import registerReducer from '../register/reducer';
 import competitionsReducer from '../competitions/reducer';
 import microCommunitiesReducer from '../microCommunities/reducer';
 import onboardReducer from '../onboard/reducer';
-import competitionsLeaderboardReducer from '../competitions/Leaderboard/reducer';
 
 export default combineReducers({
   login: loginReducer,
@@ -37,5 +36,4 @@ export default combineReducers({
   competitions: competitionsReducer,
   microCommunities: microCommunitiesReducer,
   onboard: onboardReducer,
-  competitionsLeaderboard: competitionsLeaderboardReducer,
 });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,6 @@
 export default {
   BACKEND_URL: {
-    V2: 'https://api.hapramp.com/api/v2',
+    V2: 'https://testapi.hapramp.com/api/v2',
   },
   MESSAGES: {
     AUTH: {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,6 @@
 export default {
   BACKEND_URL: {
-    V2: 'https://testapi.hapramp.com/api/v2',
+    V2: 'https://api.hapramp.com/api/v2',
   },
   MESSAGES: {
     AUTH: {

--- a/src/utils/haprampAPI.js
+++ b/src/utils/haprampAPI.js
@@ -128,7 +128,13 @@ export default {
       },
     ).then(validateJsonResponse),
     competitions: {
+      // Endpoints related to fetching contest related data
       getAll: () => fetch(`${constants.BACKEND_URL.V2}/competitions`)
+        .then(validateJsonResponse),
+      getCompetitions: (limit = 10, startAfterId = null) =>
+        fetch(`${constants.BACKEND_URL.V2}/competitions/~list?limit=${limit}${startAfterId ? `&start_after_id=${startAfterId}` : ''}`)
+          .then(validateJsonResponse),
+      getCompetition: competitionId => fetch(`${constants.BACKEND_URL.V2}/competitions/${competitionId}`)
         .then(validateJsonResponse),
       getCompetitionPosts: competitionId => fetch(`${constants.BACKEND_URL.V2}/competitions/${competitionId}/posts`)
         .then(validateJsonResponse),
@@ -136,6 +142,96 @@ export default {
         .then(validateJsonResponse),
       getLeaderboard: () => fetch(`${constants.BACKEND_URL.V2}/competitions/leaderboard`)
         .then(validateJsonResponse),
+
+      // Delete and update
+      deleteCompetition: competitionId => fetch(
+        `${constants.BACKEND_URL.V2}/competitions/${competitionId}`,
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Token ${Cookie.get('1ramp_token')}`,
+          },
+        },
+      ).then(validateJsonResponse),
+      updateCompetition: (competitionId, body) => fetch(
+        `${constants.BACKEND_URL.V2}/competitions/${competitionId}`,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Token ${Cookie.get('1ramp_token')}`,
+          },
+          body: JSON.stringify(body),
+        },
+      ).then(validateJsonResponse),
+
+      // Endpoints related to creating contests
+      createCompetition: body => fetch(
+        `${constants.BACKEND_URL.V2}/competitions`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Token ${Cookie.get('1ramp_token')}`,
+          },
+          body: JSON.stringify(body),
+        },
+      ).then(validateJsonResponse),
+      getCompetitionPostBody: (competitionId, type) =>
+        /**
+         * Used to get body for Steem posts which are suitable for contest
+         * specefic actions
+         *
+         * 'type' can be
+         *  - announce: gets body for the post used to announce cretion of a new contest
+         *  - winners: gets a body which is suitable for declaring results for a contest
+         */
+        fetch(`${constants.BACKEND_URL.V2}/competitions/${competitionId}/body/${type}`)
+          .then(validateJsonResponse),
+      registerAnnouncementPermlink: (competitionId, blogType, author, permlink) => fetch(
+        /**
+         * Used to notify the backend about mapping for steem posts to competitions for
+         * different events: competition announcement and winner declaration.
+         *
+         * 'blogType' can be
+         *  - announce: For competition announcement blog
+         *  - declare_winners: For winner declaration blog
+         */
+        `${constants.BACKEND_URL.V2}/competitions/${competitionId}/register-permlink/${blogType}?permlink=${author}/${permlink}`,
+        {
+          headers: {
+            Authorization: `Token ${Cookie.get('1ramp_token')}`,
+          },
+        },
+      ).then(validateJsonResponse),
+      setWinners: (competitionId, ranks) => fetch(
+        /**
+         * Updates rankings for a competition before announcing the results.
+         * The rankings are not made public until the results are declared.
+         */
+        `${constants.BACKEND_URL.V2}/competitions/${competitionId}/winners`,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Token ${Cookie.get('1ramp_token')}`,
+          },
+          body: JSON.stringify({ ranks }),
+        },
+      ).then(validateJsonResponse),
+      announceResults: competitionId => fetch(
+        /**
+         * Marks competition as "results declared" and the rankings
+         * set using 'setWinners` is now public.
+         */
+        `${constants.BACKEND_URL.V2}/competitions/${competitionId}/winners/announce`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Token ${Cookie.get('1ramp_token')}`,
+          },
+        },
+      ).then(validateJsonResponse),
     },
     microCommunities: {
       getAll: () => fetch(`${constants.BACKEND_URL.V2}/micro-communities`)


### PR DESCRIPTION
This pull request adds features to create and manage contests from the web app.

### The button to create a new competition - 
![screenshot from 2019-02-26 14-28-26](https://user-images.githubusercontent.com/10860278/53399951-e6d2c980-39d2-11e9-8790-b7c2393ced77.png)

### Entering competition description -
![screenshot from 2019-02-26 14-30-35](https://user-images.githubusercontent.com/10860278/53400107-2e595580-39d3-11e9-91ce-fdd4478bc526.png)

### Entering competition details - 
![localhost_3000_competitions__create_details](https://user-images.githubusercontent.com/10860278/53400299-8e4ffc00-39d3-11e9-8946-8cd7001bf699.png)

### Writing competition announcement blog - 
![localhost_3000_competitions__create_details ipad pro](https://user-images.githubusercontent.com/10860278/53400465-e850c180-39d3-11e9-8d6a-9da3bdb94d83.png)

### Choosing winning entries -
![screenshot from 2019-02-26 14-37-50](https://user-images.githubusercontent.com/10860278/53400562-277f1280-39d4-11e9-82c3-61926a2079f8.png)