### PR TITLE
Fix winner announcement route

### DIFF
--- a/src/competitions/create/AnnouncementPost/actions.js
+++ b/src/competitions/create/AnnouncementPost/actions.js
@@ -110,7 +110,7 @@ export const registerAndCreatePost = (competitionId, announcementMode) =>
        * get a message asking not to retry.
        */
       const errorText = 'There was some error registering the post. If already posted to Steem, do not retry and contact @the1ramp.';
-      console.error('[Unable to register post', reason, errorText);
+      console.error('Unable to register post', reason, errorText);
       notify.danger('There was some error registering the post. If already posted to Steem, do not retry and contact @the1ramp.');
       return dispatch({
         type: actionTypes.registerAndCreatePost.error,
@@ -128,7 +128,7 @@ export const registerAndCreatePost = (competitionId, announcementMode) =>
  */
 export const fillAnnouncementPost = (competitionId, mode) =>
   async (dispatch, getState, { haprampAPI }) => {
-    const realMode = mode === 'declare-winners' ? 'winners' : mode;
+    const realMode = mode === 'declare_winners' ? 'winners' : mode;
     const state = getState();
     const competition = getCompetitionById(state, competitionId);
     if (competition) {

--- a/src/competitions/create/AnnouncementPost/index.js
+++ b/src/competitions/create/AnnouncementPost/index.js
@@ -26,7 +26,7 @@ const getInstructionString = (mode, competition) => {
   if (mode === 'announce') {
     return `Publish the contest announcement blog for "${title}".`;
   }
-  if (mode === 'declare-winners') {
+  if (mode === 'declare_winners') {
     return `Publish the winner announcement blog for "${title}".`;
   }
   return 'Publish competition blog.';

--- a/src/competitions/create/routes.js
+++ b/src/competitions/create/routes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Switch, Route, Redirect } from 'react-router-dom';
 
 import Description from './newCompetition/Description';
 import Details from './newCompetition/Details';
@@ -25,6 +25,12 @@ export default () => (
       render={({ match }) => {
         const { params } = match;
         const { competitionId, mode } = params;
+
+        // Announcement can be one of these only
+        if (!['declare_winners', 'announce'].find(i => i === mode)) {
+          return <Redirect to="/competitions" />;
+        }
+
         return <AnnouncementPost competitionId={competitionId} mode={mode} />;
       }}
     />,


### PR DESCRIPTION
Move from `declare-winners` to `declare_winners` to be consistent with the backend APIs.